### PR TITLE
Soap gateway test topic

### DIFF
--- a/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
@@ -115,8 +115,8 @@ public class SOAPGatewayTest {
         SOAPProvider provider = new SOAPProvider();
         _domain.registerService(PUBLISH_AS_WS_SERVICE, provider);
 
-        String host = System.getProperty("org.switchyard.test.soap.host");
-        String port = System.getProperty("org.switchyard.test.soap.port");
+        String host = System.getProperty("org.switchyard.test.soap.host", "localhost");
+        String port = System.getProperty("org.switchyard.test.soap.port", "48080");
 
         // Service exposed as WS
         _soapInbound = new SOAPGateway();


### PR DESCRIPTION
I was not able to run this test directly from my IDE without first setting the system properties 'org.switchyard.test.soap.host' and 'org.switchyard.test.soap.port'. This pull request suggests adding default values for these variable when calling System.getProperty.
