### PR TITLE
Work for SWITCHYARD-217 "Camel component fails on deploy in AS6"

### DIFF
--- a/camel/src/test/java/org/switchyard/component/camel/deploy/CamelActivatorTest.java
+++ b/camel/src/test/java/org/switchyard/component/camel/deploy/CamelActivatorTest.java
@@ -21,12 +21,15 @@
 package org.switchyard.component.camel.deploy;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
+import org.apache.camel.spi.PackageScanClassResolver;
 import org.junit.Test;
+import org.switchyard.component.camel.deploy.support.CustomPackageScanResolver;
 import org.switchyard.test.MockHandler;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.SwitchYardTestCase;
@@ -53,6 +56,13 @@ public class CamelActivatorTest extends SwitchYardTestCase {
         producerTemplate.sendBody("direct://input2", "dummy payload");
         assertOneMessage(mockHandler, "dummy payload");
     }
+    
+    @Test
+    public void setCustomClassPathResolver() {
+        final CamelContext camelContext = CamelActivator.getCamelContext();
+        final PackageScanClassResolver p = camelContext.getPackageScanClassResolver();
+        assertThat(p, is(instanceOf(CustomPackageScanResolver.class)));
+   }
     
     private void assertOneMessage(final MockHandler mockHandler, final String expectedPayload)
     {

--- a/camel/src/test/java/org/switchyard/component/camel/deploy/support/CustomPackageScanResolver.java
+++ b/camel/src/test/java/org/switchyard/component/camel/deploy/support/CustomPackageScanResolver.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.deploy.support;
+
+import org.apache.camel.impl.DefaultPackageScanClassResolver;
+
+public class CustomPackageScanResolver extends DefaultPackageScanClassResolver {
+}

--- a/camel/src/test/resources/META-INF/services/org.apache.camel.spi.PackageScanClassResolver
+++ b/camel/src/test/resources/META-INF/services/org.apache.camel.spi.PackageScanClassResolver
@@ -1,0 +1,1 @@
+org.switchyard.component.camel.deploy.support.CustomPackageScanResolver


### PR DESCRIPTION
The suggested solution is to use a Service loader to load the
PackageScanClassResolver. We could then stick a file in the jboss6
deployer jar and users would be able to use the SwitchYard Camel
component by only adding the Camel-Extra jar to the servers lib
directory.
