### PR TITLE
SWITCHYARD-224 "Make the operationSelector operationName optional"

### DIFF
--- a/camel/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-test.xml
+++ b/camel/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-test.xml
@@ -21,9 +21,7 @@
     <sca:composite>
     
         <sca:service name="SimpleCamelService">
-            <camel:binding.camel configURI="direct://input">
-			    <camel:operationSelector operationName="print"/>
-            </camel:binding.camel>
+            <camel:binding.camel configURI="direct://input"/>
             <camel:binding.camel configURI="direct://input2">
 			    <camel:operationSelector operationName="print"/>
             </camel:binding.camel>


### PR DESCRIPTION
Make the operationSelector operationName optional if the service interface only exposes one operation. We can use the ServiceReference to lookup the operationName and save users from having to explicitly specify the operationName.
