### PR TITLE
SWITCHYARD-305: bean component needs to use message.getContent(<type>) wh

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/Invocation.java
+++ b/bean/src/main/java/org/switchyard/component/bean/Invocation.java
@@ -20,6 +20,7 @@
 package org.switchyard.component.bean;
 
 import org.switchyard.Exchange;
+import org.switchyard.Message;
 
 import java.lang.reflect.Method;
 
@@ -54,7 +55,7 @@ public class Invocation {
     Invocation(Method method, Exchange exchange) throws BeanComponentException {
         this._method = method;
         this._exchange = exchange;
-        this._args = castArg(method, exchange.getMessage().getContent());
+        this._args = castArg(method, exchange.getMessage());
         assertOK();
     }
 
@@ -85,13 +86,9 @@ public class Invocation {
         return _method;
     }
 
-    private static Object[] castArg(Method method, Object content) {
-        if (method.getParameterTypes().length == 1 && content != null) {
-            if (content.getClass().isArray()) {
-                return (Object[].class).cast(content);
-            } else {
-                return new Object[]{content};
-            }
+    private static Object[] castArg(Method method, Message message) {
+        if (method.getParameterTypes().length == 1 && message != null) {
+            return new Object[]{message.getContent(method.getParameterTypes()[0])};
         }
         return null;
     }

--- a/bean/src/test/java/org/switchyard/component/bean/tests/ConsumerBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/ConsumerBean.java
@@ -20,10 +20,20 @@
 package org.switchyard.component.bean.tests;
 
 import javax.inject.Inject;
+import javax.xml.parsers.ParserConfigurationException;
 
+import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Assert;
+import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.component.bean.Reference;
 import org.switchyard.component.bean.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.StringReader;
 
 @Service(ConsumerService.class)
 public class ConsumerBean implements ConsumerService {
@@ -53,5 +63,17 @@ public class ConsumerBean implements ConsumerService {
             // and throw a new exception...
             throw new ConsumerException("remote-exception-received");
         }
+    }
+
+
+    @Override
+    public String domOperation(Document message) {
+        try {
+            XMLUnit.compareXML(XMLHelper.getDocument(new InputSource(new StringReader("<a><b/></a>"))), message);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        return "<c/>";
     }
 }

--- a/bean/src/test/java/org/switchyard/component/bean/tests/ConsumerService.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/ConsumerService.java
@@ -1,5 +1,7 @@
 package org.switchyard.component.bean.tests;
 
+import org.w3c.dom.Document;
+
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
@@ -7,4 +9,6 @@ public interface ConsumerService {
     void consumeInOnlyService(Object message);
 
     Object consumeInOutService(Object message) throws ConsumerException;
+
+    String domOperation(Document message);
 }

--- a/bean/src/test/java/org/switchyard/component/bean/tests/InputTypeMismatchTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/InputTypeMismatchTest.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.Message;
+import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.mixins.CDIMixIn;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
+public class InputTypeMismatchTest extends SwitchYardTestCase {
+
+    @Test
+    public void test_invokeWithWrongInputParameterType() {
+        // A basic type conversion should happen automatically...
+        Message response = newInvoker("ConsumerService.domOperation").sendInOut("<a><b/></a>");
+
+        Assert.assertEquals("<c/>", response.getContent());
+    }
+}


### PR DESCRIPTION
SWITCHYARD-305: bean component needs to use message.getContent(<type>) when handling invocations
