### PR TITLE
SWITCHYARD-318: ClientProxyBean.createExchange does not set exchange cont

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/SwitchYardCDIServiceDiscovery.java
+++ b/bean/src/main/java/org/switchyard/component/bean/SwitchYardCDIServiceDiscovery.java
@@ -125,7 +125,13 @@ public class SwitchYardCDIServiceDiscovery implements Extension {
     }
 
     private void addInjectableClientProxyBean(Field injectionPointField, Reference serviceReference, Set<Annotation> qualifiers, BeanManager beanManager) {
-        QName serviceQName = toServiceQName(injectionPointField.getType());
+        QName serviceQName;
+
+        if (serviceReference.value().length() > 0) {
+            serviceQName = QName.valueOf(serviceReference.value());
+        } else {
+            serviceQName = toServiceQName(injectionPointField.getType());
+        }
 
         addClientProxyBean(serviceQName, injectionPointField.getType(), qualifiers);
     }

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService1.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService1.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface InventoryClientService1 {
+
+    String doStuff(String input);
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService1Bean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService1Bean.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref;
+
+import org.switchyard.component.bean.Reference;
+import org.switchyard.component.bean.Service;
+import org.switchyard.component.bean.multiversionref.oldinvservice.A;
+import org.switchyard.component.bean.multiversionref.oldinvservice.OldInventoryService;
+
+import javax.inject.Inject;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Service(InventoryClientService1.class)
+public class InventoryClientService1Bean implements InventoryClientService1 {
+
+    @Inject @Reference("InventoryService")
+    private OldInventoryService oldInventoryService;
+
+    @Override
+    public String doStuff(String input) {
+        A result = oldInventoryService.getInventory(new A());
+        return "old";
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService2.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService2.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface InventoryClientService2 {
+
+    String doStuff(String input);
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService2Bean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/InventoryClientService2Bean.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref;
+
+import org.switchyard.component.bean.Reference;
+import org.switchyard.component.bean.Service;
+import org.switchyard.component.bean.multiversionref.newinvservice.B;
+import org.switchyard.component.bean.multiversionref.newinvservice.InventoryService;
+
+import javax.inject.Inject;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Service(InventoryClientService2.class)
+public class InventoryClientService2Bean implements InventoryClientService2 {
+
+    @Inject @Reference("InventoryService")
+    private InventoryService newInventoryService;
+
+    @Override
+    public String doStuff(String input) {
+        B result = newInventoryService.getInventory(new B());
+        return "new";
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/MultiVersionServiceTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/MultiVersionServiceTest.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.mixins.CDIMixIn;
+
+/**
+ * This test is testing checking that @Referenced services can be invoked
+ * through old and new interfaces and that the appropriate input/output
+ * parameter transformations are automatically applied based on the ExchangeContract
+ * information specified in the ClientBeanProxyHandler.
+ * <p/>
+ * InventoryClientService1 uses the old inventory interface to invoke the inventory service,
+ * while InventoryClientService2 uses the new inventory interface.  In both cases, they are
+ * invoking the same backend service (the new version).  SwitchYard ensures that the appropriate
+ * type transformation happen for InventoryClientService1.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
+public class MultiVersionServiceTest extends SwitchYardTestCase {
+
+    @Test
+    public void test_InventoryClientService1() {
+        String response = newInvoker("InventoryClientService1.doStuff").sendInOut("hello").getContent(String.class);
+
+        Assert.assertEquals("old", response);
+    }
+
+    @Test
+    public void test_InventoryClientService2() {
+        String response = newInvoker("InventoryClientService2.doStuff").sendInOut("hello").getContent(String.class);
+
+        Assert.assertEquals("new", response);
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/B.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/B.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.newinvservice;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class B {
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/InventoryService.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/InventoryService.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.newinvservice;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface InventoryService {
+
+    B getInventory(B b);
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/NewInventoryServiceBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/NewInventoryServiceBean.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.newinvservice;
+
+import org.switchyard.component.bean.Service;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+@Service(InventoryService.class)
+public class NewInventoryServiceBean implements InventoryService {
+
+    @Override
+    public B getInventory(B b) {
+        return b;
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/Transformers.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/newinvservice/Transformers.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.newinvservice;
+
+import org.switchyard.annotations.Transformer;
+import org.switchyard.component.bean.multiversionref.oldinvservice.A;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class Transformers {
+
+    @Transformer
+    public B transformA2B(A a) {
+        return new B();
+    }
+
+    @Transformer
+    public A transformB2A(B b) {
+        return new A();
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/oldinvservice/A.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/oldinvservice/A.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.oldinvservice;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class A {
+}

--- a/bean/src/test/java/org/switchyard/component/bean/multiversionref/oldinvservice/OldInventoryService.java
+++ b/bean/src/test/java/org/switchyard/component/bean/multiversionref/oldinvservice/OldInventoryService.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.multiversionref.oldinvservice;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public interface OldInventoryService {
+
+    A getInventory(A a);
+}

--- a/soap/src/build/resources/module.xml
+++ b/soap/src/build/resources/module.xml
@@ -32,6 +32,7 @@
         <module name="javax.api"/>
         <module name="javax.wsdl4j.api"/>
         <module name="javax.xml.soap.api"/>
+        <module name="com.sun.xml.messaging.saaj" export="true"/>
         <module name="javax.xml.ws.api"/>
         <module name="org.apache.log4j"/>
         <module name="org.switchyard.api"/>


### PR DESCRIPTION
SWITCHYARD-318: ClientProxyBean.createExchange does not set exchange contract

https://issues.jboss.org/browse/SWITCHYARD-318
