### PR TITLE
SWITCHYARD-339 use correct version numbers for clojure component

### DIFF
--- a/clojure/assembly.xml
+++ b/clojure/assembly.xml
@@ -25,7 +25,7 @@
           <include>org.switchyard.components:switchyard-component-clojure</include>
        </includes>
        <outputDirectory>/modules/org/switchyard/component/clojure/main</outputDirectory>
-       <outputFileNameMapping>${artifact.artifactId}-${version.clojure}.${artifact.extension}</outputFileNameMapping>
+       <outputFileNameMapping>${artifact.artifactId}-${version.project}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
     <dependencySet>
        <useTransitiveDependencies>false</useTransitiveDependencies>
@@ -33,7 +33,7 @@
           <include>org.clojure:clojure</include>
        </includes>
        <outputDirectory>/modules/org/clojure/clojure/main</outputDirectory>
-       <outputFileNameMapping>${artifact.artifactId}-${version.project}.${artifact.extension}</outputFileNameMapping>
+       <outputFileNameMapping>${artifact.artifactId}-${version.clojure}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>
 </assembly>


### PR DESCRIPTION
version numbers for Clojure jar and component jar were reversed
