### PR TITLE
SWITCHYARD-352 switchyard-forge-soap-plugin package name should be soap i

### DIFF
--- a/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPBindingPlugin.java
+++ b/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPBindingPlugin.java
@@ -17,7 +17,7 @@
  * MA  02110-1301, USA.
  */
 
-package org.switchyard.tools.forge.camel;
+package org.switchyard.tools.forge.soap;
 
 import javax.inject.Inject;
 

--- a/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPFacet.java
+++ b/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPFacet.java
@@ -17,7 +17,7 @@
  * MA  02110-1301, USA.
  */
 
-package org.switchyard.tools.forge.camel;
+package org.switchyard.tools.forge.soap;
 
 import org.jboss.forge.project.facets.DependencyFacet;
 import org.jboss.forge.project.facets.PackagingFacet;


### PR DESCRIPTION
SWITCHYARD-352 switchyard-forge-soap-plugin package name should be soap instead of camel
