### PR TITLE
SWITCHYARD-356: Use of enum for ResourceType restricts extensibility

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/Process.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/Process.java
@@ -20,15 +20,13 @@ package org.switchyard.component.bpm;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.switchyard.common.io.resource.ResourceType.BPMN2;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import org.switchyard.common.io.resource.SimpleResource;
 import org.switchyard.common.io.resource.Resource;
-import org.switchyard.common.io.resource.ResourceType;
+import org.switchyard.common.io.resource.SimpleResource;
 import org.switchyard.component.bpm.task.BaseTaskHandler;
 import org.switchyard.component.bpm.task.TaskHandler;
 
@@ -55,7 +53,7 @@ public @interface Process {
     /**
      * Specified process definition type.
      */
-    public ResourceType definitionType() default BPMN2;
+    public String definitionType() default BPMN2;
 
     /**
      * Specified process id.
@@ -76,6 +74,8 @@ public @interface Process {
     public static interface UndefinedProcessInterface {};
     /** An undefined process definition. */
     public static final String UNDEFINED_PROCESS_DEFINITION = "";
+    /** The BPMN2 ResourceType name . */
+    public static final String BPMN2 = "BPMN2";
     /** An undefined process id. */
     public static final String UNDEFINED_PROCESS_ID = "";
     /** An undefined process resource. */

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BpmComponentImplementationModel.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BpmComponentImplementationModel.java
@@ -106,7 +106,7 @@ public class V1BpmComponentImplementationModel extends V1ComponentImplementation
     public BpmComponentImplementationModel setProcessDefinition(Resource processDefinition) {
         setModelAttribute(PROCESS_DEFINITION, processDefinition != null ? processDefinition.getLocation() : null);
         ResourceType pdt = processDefinition != null ? processDefinition.getType() : null;
-        setModelAttribute(PROCESS_DEFINITION_TYPE, pdt != null ? pdt.name() : null);
+        setModelAttribute(PROCESS_DEFINITION_TYPE, pdt != null ? pdt.getName() : null);
         return this;
     }
 

--- a/bpm/src/main/java/org/switchyard/component/bpm/exchange/drools/DroolsBpmExchangeHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/exchange/drools/DroolsBpmExchangeHandler.java
@@ -117,9 +117,9 @@ public class DroolsBpmExchangeHandler extends BaseBpmExchangeHandler {
             org.drools.io.Resource kres = ResourceFactory.newUrlResource(resource.getLocationURL());
             ResourceType resourceType = resource.getType();
             if (resourceType == null) {
-                resourceType = ResourceType.BPMN2;
+                resourceType = ResourceType.valueOf("BPMN2");
             }
-            org.drools.builder.ResourceType kresType = org.drools.builder.ResourceType.getResourceType(resourceType.name());
+            org.drools.builder.ResourceType kresType = org.drools.builder.ResourceType.getResourceType(resourceType.getName());
             kbuilder.add(kres, kresType);
         }
     }

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/BpmModelTests.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/BpmModelTests.java
@@ -74,7 +74,7 @@ public class BpmModelTests {
         BpmComponentImplementationModel bci = (BpmComponentImplementationModel)implementation;
         Assert.assertEquals("bpm", bci.getType());
         Assert.assertEquals("foobar.bpmn", bci.getProcessDefinition().getLocation());
-        Assert.assertEquals("BPMN2", bci.getProcessDefinition().getType().name());
+        Assert.assertSame(ResourceType.valueOf("BPMN2"), bci.getProcessDefinition().getType());
         Assert.assertEquals("foobar", bci.getProcessId());
         Configuration config = bci.getModelConfiguration();
         Assert.assertEquals("implementation.bpm", config.getName());
@@ -83,7 +83,7 @@ public class BpmModelTests {
         Assert.assertEquals("implementation.bpm", qname.getLocalPart());
         ResourceModel prm = bci.getResources().iterator().next();
         Assert.assertEquals("foobar.drl", prm.getLocation());
-        Assert.assertEquals(ResourceType.DRL, prm.getType());
+        Assert.assertSame(ResourceType.valueOf("DRL"), prm.getType());
         TaskHandlerModel tih = bci.getTaskHandlers().iterator().next();
         Assert.assertEquals(SwitchYardServiceTaskHandler.class, tih.getClazz());
         Assert.assertNull(tih.getName());
@@ -125,17 +125,17 @@ public class BpmModelTests {
             String processId = bci.getProcessId();
             if ("SimpleProcess".equals(processId)) {
                 Assert.assertEquals("META-INF/SimpleProcess.bpmn", bci.getProcessDefinition().getLocation());
-                Assert.assertEquals(ResourceType.BPMN2, bci.getProcessDefinition().getType());
+                Assert.assertSame(ResourceType.valueOf("BPMN2"), bci.getProcessDefinition().getType());
             } else if ("ComplexProcess".equals(processId)) {
                 Assert.assertEquals("path/to/my.bpmn", bci.getProcessDefinition().getLocation());
-                Assert.assertEquals(ResourceType.BPMN2, bci.getProcessDefinition().getType());
+                Assert.assertSame(ResourceType.valueOf("BPMN2"), bci.getProcessDefinition().getType());
                 Iterator<ResourceModel> prm_iter = bci.getResources().iterator();
                 ResourceModel prm = prm_iter.next();
                 Assert.assertEquals("path/to/my.dsl", prm.getLocation());
-                Assert.assertEquals(ResourceType.DSL, prm.getType());
+                Assert.assertSame(ResourceType.valueOf("DSL"), prm.getType());
                 prm = prm_iter.next();
                 Assert.assertEquals("path/to/my.dslr", prm.getLocation());
-                Assert.assertEquals(ResourceType.DSLR, prm.getType());
+                Assert.assertSame(ResourceType.valueOf("DSLR"), prm.getType());
                 Iterator<TaskHandlerModel> wih_iter = bci.getTaskHandlers().iterator();
                 TaskHandlerModel wih = wih_iter.next();
                 Assert.assertEquals(SwitchYardServiceTaskHandler.class, wih.getClazz());

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/ComplexProcess.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/ComplexProcess.java
@@ -18,10 +18,6 @@
  */
 package org.switchyard.component.bpm.config.model;
 
-import static org.switchyard.common.io.resource.ResourceType.BPMN2;
-import static org.switchyard.common.io.resource.ResourceType.DSL;
-import static org.switchyard.common.io.resource.ResourceType.DSLR;
-
 import org.switchyard.common.io.resource.SimpleResource;
 import org.switchyard.component.bpm.Process;
 import org.switchyard.component.bpm.config.model.ComplexProcess.My1stHandler;
@@ -41,7 +37,7 @@ import org.switchyard.component.bpm.task.TaskManager;
 @Process(
     value=ProcessIface.class,
     definition="path/to/my.bpmn",
-    definitionType=BPMN2,
+    definitionType="BPMN2",
     id="ComplexProcess",
     resources={MyDsl.class, MyDslr.class},
     taskHandlers={My1stHandler.class, My2ndHandler.class})
@@ -51,13 +47,13 @@ public interface ComplexProcess {
 
     public static final class MyDsl extends SimpleResource {
         public MyDsl() {
-            super("path/to/my.dsl", DSL);
+            super("path/to/my.dsl", "DSL");
         }
     }
 
     public static final class MyDslr extends SimpleResource {
         public MyDslr() {
-            super("path/to/my.dslr", DSLR);
+            super("path/to/my.dslr", "DSLR");
         }
     }
 

--- a/bpm/src/test/java/org/switchyard/component/bpm/drools/BpmDroolsTests.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/drools/BpmDroolsTests.java
@@ -20,7 +20,6 @@ package org.switchyard.component.bpm.drools;
 
 import static org.switchyard.Scope.IN;
 import static org.switchyard.Scope.OUT;
-import static org.switchyard.common.io.resource.ResourceType.BPMN2;
 import static org.switchyard.component.bpm.common.ProcessActionType.SIGNAL_EVENT;
 import static org.switchyard.component.bpm.common.ProcessActionType.START_PROCESS;
 import static org.switchyard.component.bpm.common.ProcessConstants.PROCESS_ACTION_TYPE_VAR;
@@ -103,7 +102,7 @@ public class BpmDroolsTests {
         BpmExchangeHandler handler = BpmExchangeHandlerFactory.instance().newBpmExchangeHandler(serviceDomain);
         ServiceReference serviceRef = serviceDomain.registerService(qname, handler);
         BpmComponentImplementationModel bci_model = new V1BpmComponentImplementationModel();
-        bci_model.setProcessDefinition(new SimpleResource(TEST_CONTROL_PROCESS, BPMN2));
+        bci_model.setProcessDefinition(new SimpleResource(TEST_CONTROL_PROCESS, "BPMN2"));
         bci_model.setProcessId(qname.getLocalPart());
         bci_model.addTaskHandler(new V1TaskHandlerModel().setClazz(SwitchYardServiceTaskHandler.class).setName(SwitchYardServiceTaskHandler.SWITCHYARD_SERVICE));
         handler.init(qname, bci_model);
@@ -131,7 +130,7 @@ public class BpmDroolsTests {
         BpmExchangeHandler handler = BpmExchangeHandlerFactory.instance().newBpmExchangeHandler(serviceDomain);
         ServiceReference serviceRef = serviceDomain.registerService(qname, handler);
         BpmComponentImplementationModel bci_model = new V1BpmComponentImplementationModel();
-        bci_model.setProcessDefinition(new SimpleResource(TEST_REUSE_HANDLER, BPMN2));
+        bci_model.setProcessDefinition(new SimpleResource(TEST_REUSE_HANDLER, "BPMN2"));
         bci_model.setProcessId(qname.getLocalPart());
         bci_model.addTaskHandler(new V1TaskHandlerModel().setClazz(ReuseHandler.class).setName(qname.getLocalPart()));
         handler.init(qname, bci_model);

--- a/rules/src/main/java/org/switchyard/component/rules/exchange/drools/DroolsRulesExchangeHandler.java
+++ b/rules/src/main/java/org/switchyard/component/rules/exchange/drools/DroolsRulesExchangeHandler.java
@@ -98,7 +98,7 @@ public class DroolsRulesExchangeHandler extends BaseRulesExchangeHandler {
             ResourceType resourceType = resource.getType();
             if (resourceType != null) {
                 org.drools.io.Resource kres = ResourceFactory.newUrlResource(resource.getLocationURL());
-                org.drools.builder.ResourceType kresType = org.drools.builder.ResourceType.getResourceType(resourceType.name());
+                org.drools.builder.ResourceType kresType = org.drools.builder.ResourceType.getResourceType(resourceType.getName());
                 kbuilder.add(kres, kresType);
             }
         }

--- a/rules/src/test/java/org/switchyard/component/rules/config/model/DoStuffRules.java
+++ b/rules/src/test/java/org/switchyard/component/rules/config/model/DoStuffRules.java
@@ -18,8 +18,6 @@
  */
 package org.switchyard.component.rules.config.model;
 
-import static org.switchyard.common.io.resource.ResourceType.DRL;
-
 import org.switchyard.common.io.resource.SimpleResource;
 import org.switchyard.component.rules.ExecuteRules;
 import org.switchyard.component.rules.Rules;
@@ -37,7 +35,7 @@ public interface DoStuffRules extends DoStuff {
 
     public static final class MyDrl extends SimpleResource {
         public MyDrl() {
-            super("path/to/my.drl", DRL);
+            super("path/to/my.drl", "DRL");
         }
     }
 

--- a/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
+++ b/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
@@ -75,10 +75,10 @@ public class RulesModelTests {
         Iterator<ResourceModel> resource_iter = rci.getResources().iterator();
         Resource dsl = resource_iter.next();
         Assert.assertEquals("foo.dsl", dsl.getLocation());
-        Assert.assertEquals(ResourceType.DSL, dsl.getType());
+        Assert.assertSame(ResourceType.valueOf("DSL"), dsl.getType());
         Resource dslr = resource_iter.next();
         Assert.assertEquals("bar.dslr", dslr.getLocation());
-        Assert.assertEquals(ResourceType.DSLR, dslr.getType());
+        Assert.assertSame(ResourceType.valueOf("DSLR"), dslr.getType());
         RulesAuditModel ram = rci.getRulesAudit();
         Assert.assertNotNull(ram);
         Assert.assertEquals(Integer.valueOf(2000), ram.getInterval());
@@ -122,7 +122,7 @@ public class RulesModelTests {
             Iterator<ResourceModel> rm_iter = rci.getResources().iterator();
             ResourceModel rm = rm_iter.next();
             Assert.assertEquals("path/to/my.drl", rm.getLocation());
-            Assert.assertEquals(ResourceType.DRL, rm.getType());
+            Assert.assertSame(ResourceType.valueOf("DRL"), rm.getType());
         }
     }
 


### PR DESCRIPTION
SWITCHYARD-356: Use of enum for ResourceType restricts extensibility
https://issues.jboss.org/browse/SWITCHYARD-356
