### PR TITLE
SWITCHYARD-351: targetNamespace being lost by switchyard plugin (ConfigMo

### DIFF
--- a/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
+++ b/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
@@ -18,7 +18,7 @@
   ~ MA  02110-1301, USA.
   -->
 
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="m1app" targetNamespace="urn:switchyard-quickstarts:m1app:0.1.0-SNAPSHOT">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app">
         <sca:service xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="OrderService" promote="OrderService">
             <soap:binding.soap xmlns:soap="urn:switchyard-component-soap:config:1.0">


### PR DESCRIPTION
SWITCHYARD-351: targetNamespace being lost by switchyard plugin (ConfigMojo) during final switchyard.xml generation
https://issues.jboss.org/browse/SWITCHYARD-351
