### PR TITLE
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/Service.java
+++ b/bean/src/main/java/org/switchyard/component/bean/Service.java
@@ -48,6 +48,11 @@ public @interface Service {
     String name() default EMPTY;
     
     /**
+     * Optional Service namespace.
+     */
+    String namespace() default EMPTY;
+    
+    /**
      * Constant representing a null (i.e. unassigned) value.
      * Annotations are not allowed to have empty values, so a default
      * representation for an empty value is used.

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/ComponentNameComposer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/ComponentNameComposer.java
@@ -64,7 +64,7 @@ public final class ComponentNameComposer {
     public static QName componseSwitchYardServiceName(final String uri) {
         final URI create = URI.create(uri);
         final String path = create.getAuthority();
-        return new QName(path);
+        return QName.valueOf(path);
     }
     
 }

--- a/tests/src/test/resources/soap.bindingReference/switchyard.xml
+++ b/tests/src/test/resources/soap.bindingReference/switchyard.xml
@@ -25,7 +25,7 @@ MA  02110-1301, USA.
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
             targetNamespace="urn:switchyard-quickstarts:bindingReference:1.0-SNAPSHOT"
             name="bindingReference">
-    <sca:composite name="bindingReference" targetNamespace="urn:m1app:example:1.0">
+    <sca:composite name="bindingReference">
         <sca:reference name="DummySOAPServiceService">
             <soap:binding.soap>
                 <soap:wsdl>soap.bindingReference/dummyService.wsdl</soap:wsdl>


### PR DESCRIPTION
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()
https://issues.jboss.org/browse/SWITCHYARD-365
