### PR TITLE
SWITCHYARD-390: Duplicate Transfomer 'org.switchyard.component.hornetq.tr

### DIFF
--- a/hornetq/src/test/resources/META-INF/switchyard/transforms.xml
+++ b/hornetq/src/test/resources/META-INF/switchyard/transforms.xml
@@ -1,6 +1,0 @@
-<transforms xmlns="urn:switchyard-config:switchyard:1.0">
-    <transform.java xmlns="urn:switchyard-config:transform:1.0" 
-        class="org.switchyard.component.hornetq.transformer.ByteArrayToStringTransformer" 
-        from="java:byte[]" 
-        to="java:java.lang.String"/>
-</transforms>


### PR DESCRIPTION
SWITCHYARD-390: Duplicate Transfomer 'org.switchyard.component.hornetq.transformer.ByteArrayToStringTransformer' defined in main and test causes a stack trace in tests
https://issues.jboss.org/browse/SWITCHYARD-390
