### PR TITLE
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/ClientProxyBean.java
+++ b/bean/src/main/java/org/switchyard/component/bean/ClientProxyBean.java
@@ -36,14 +36,13 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.util.AnnotationLiteral;
-import javax.xml.namespace.QName;
 
 import org.switchyard.Exchange;
 import org.switchyard.ExchangeHandler;
 import org.switchyard.ExchangeState;
 import org.switchyard.ServiceReference;
-import org.switchyard.component.bean.deploy.BeanDeploymentMetaData;
 import org.switchyard.SynchronousInOutHandler;
+import org.switchyard.component.bean.deploy.BeanDeploymentMetaData;
 import org.switchyard.metadata.BaseExchangeContract;
 import org.switchyard.metadata.InvocationContract;
 import org.switchyard.metadata.ServiceOperation;
@@ -60,9 +59,9 @@ import org.switchyard.metadata.java.JavaService;
 public class ClientProxyBean implements Bean {
 
     /**
-     * The target Service {@link QName}.
+     * The target Service.
      */
-    private QName _serviceQName;
+    private String _serviceName;
 
     /**
      * Target service reference.
@@ -89,13 +88,13 @@ public class ClientProxyBean implements Bean {
     /**
      * Public constructor.
      *
-     * @param serviceQName   The name of the ESB Service being proxied to.
+     * @param serviceName   The name of the ESB Service being proxied to.
      * @param proxyInterface The proxy Interface.
      * @param qualifiers     The CDI bean qualifiers.  Copied from the injection point.
      * @param beanDeploymentMetaData Deployment metadata.
      */
-    public ClientProxyBean(QName serviceQName, Class<?> proxyInterface, Set<Annotation> qualifiers, BeanDeploymentMetaData beanDeploymentMetaData) {
-        this._serviceQName = serviceQName;
+    public ClientProxyBean(String serviceName, Class<?> proxyInterface, Set<Annotation> qualifiers, BeanDeploymentMetaData beanDeploymentMetaData) {
+        this._serviceName = serviceName;
         this._serviceInterface = proxyInterface;
 
         if (qualifiers != null) {
@@ -118,8 +117,8 @@ public class ClientProxyBean implements Bean {
      *
      * @return The Service name.
      */
-    public QName getServiceQName() {
-        return _serviceQName;
+    public String getServiceName() {
+        return _serviceName;
     }
 
     /**
@@ -275,7 +274,7 @@ public class ClientProxyBean implements Bean {
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             if (_service == null) {
-                throw new BeanComponentException("A service reference to service '" + _serviceQName + "' is not bound into "
+                throw new BeanComponentException("A service reference to service '" + _serviceName + "' is not bound into "
                         + "this client proxy instance.  A reference configuration to the service may be required in the application configuration.");
             }
             
@@ -308,7 +307,7 @@ public class ClientProxyBean implements Bean {
                         }
                         throw (Throwable) exceptionObj;
                     } else {
-                        throw new BeanComponentException("Bean Component invocation failure.  Service '" + _serviceQName + "', operation '" + method.getName() + "'.").setFaultExchange(exchangeOut);
+                        throw new BeanComponentException("Bean Component invocation failure.  Service '" + _serviceName + "', operation '" + method.getName() + "'.").setFaultExchange(exchangeOut);
                     }
                 }
             } else {
@@ -330,7 +329,7 @@ public class ClientProxyBean implements Bean {
             ServiceOperation serviceOperation = service.getInterface().getOperation(operationName);
 
             if (serviceOperation == null) {
-                throw new BeanComponentException("Bean Component invocation failure.  Operation '" + operationName + "' is not defined on Service '" + _serviceQName + "'.");
+                throw new BeanComponentException("Bean Component invocation failure.  Operation '" + operationName + "' is not defined on Service '" + _serviceName + "'.");
             }
 
             BaseExchangeContract exchangeContext = new BaseExchangeContract(serviceOperation);

--- a/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
+++ b/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
@@ -87,6 +87,10 @@ public class BeanSwitchYardScanner implements Scanner<SwitchYardModel> {
                 continue;
             }
             
+            BeanComponentImplementationModel beanModel = new V1BeanComponentImplementationModel();
+            beanModel.setClazz(serviceClass.getName());
+            componentModel.setImplementation(beanModel);
+            
             Class<?> iface = service.value();
             ComponentServiceModel serviceModel = new V1ComponentServiceModel();
             JavaComponentServiceInterfaceModel csiModel = new V1JavaComponentServiceInterfaceModel();
@@ -116,10 +120,6 @@ public class BeanSwitchYardScanner implements Scanner<SwitchYardModel> {
             compositeModel.addComponent(componentModel);
             componentModel.setName(name);
             compositeModel.addComponent(componentModel);
-
-            BeanComponentImplementationModel beanModel = new V1BeanComponentImplementationModel();
-            beanModel.setClazz(serviceClass.getName());
-            componentModel.setImplementation(beanModel);
         }
 
         return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);

--- a/bean/src/main/java/org/switchyard/component/bean/deploy/BeanComponentActivator.java
+++ b/bean/src/main/java/org/switchyard/component/bean/deploy/BeanComponentActivator.java
@@ -32,7 +32,6 @@ import org.switchyard.config.model.composite.ComponentReferenceModel;
 import org.switchyard.config.model.composite.ComponentServiceModel;
 import org.switchyard.deploy.BaseActivator;
 import org.switchyard.exception.SwitchYardException;
-
 import org.switchyard.metadata.ServiceInterface;
 
 /**
@@ -65,7 +64,7 @@ public class BeanComponentActivator extends BaseActivator {
         } else if (config instanceof ComponentServiceModel) {
             // lookup the handler for the initialized service
             for (ServiceDescriptor descriptor : _beanDeploymentMetaData.getServiceDescriptors()) {
-                if (descriptor.getServiceName().equals(name)) {
+                if (descriptor.getServiceName().equals(name.getLocalPart())) {
                     return descriptor.getHandler();
                 }
             }
@@ -86,7 +85,7 @@ public class BeanComponentActivator extends BaseActivator {
      * @param name The Service Name.
      * @return The ServiceInterface instance.
      */
-    public ServiceInterface buildServiceInterface(QName name) {
+    public ServiceInterface buildServiceInterface(String name) {
         for (ServiceDescriptor descriptor : _beanDeploymentMetaData.getServiceDescriptors()) {
             if (descriptor.getServiceName().equals(name)) {
                 return descriptor.getInterface();
@@ -103,7 +102,7 @@ public class BeanComponentActivator extends BaseActivator {
     public void start(ServiceReference service) {
         // Initialise any client proxies to the started service...
         for (ClientProxyBean proxyBean : _beanDeploymentMetaData.getClientProxies()) {
-            if (proxyBean.getServiceQName().equals(service.getName())) {
+            if (proxyBean.getServiceName().equals(service.getName().getLocalPart())) {
                 proxyBean.setService(service);
             }
         }

--- a/bean/src/main/java/org/switchyard/component/bean/deploy/BeanDeploymentMetaData.java
+++ b/bean/src/main/java/org/switchyard/component/bean/deploy/BeanDeploymentMetaData.java
@@ -19,9 +19,10 @@
 
 package org.switchyard.component.bean.deploy;
 
-import org.switchyard.component.bean.ClientProxyBean;
-import org.switchyard.exception.SwitchYardException;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
@@ -29,10 +30,9 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+
+import org.switchyard.component.bean.ClientProxyBean;
+import org.switchyard.exception.SwitchYardException;
 
 /**
  * Bean Deployment Meta Data.
@@ -48,6 +48,11 @@ public class BeanDeploymentMetaData {
     private List<ServiceDescriptor> _serviceDescriptors = new ArrayList<ServiceDescriptor>();
     private List<ClientProxyBean> _clientProxies = new ArrayList<ClientProxyBean>();
     private List<CDIBean> _deploymentBeans = new ArrayList<CDIBean>();
+
+    /**
+     * Default no-arg constructor.
+     */
+    public BeanDeploymentMetaData() {}
 
     /**
      * Set the deployment CDI BeanManager.

--- a/bean/src/main/java/org/switchyard/component/bean/deploy/ServiceDescriptor.java
+++ b/bean/src/main/java/org/switchyard/component/bean/deploy/ServiceDescriptor.java
@@ -19,11 +19,10 @@
 
 package org.switchyard.component.bean.deploy;
 
+import java.io.Serializable;
+
 import org.switchyard.ExchangeHandler;
 import org.switchyard.metadata.ServiceInterface;
-
-import javax.xml.namespace.QName;
-import java.io.Serializable;
 
 /**
  * Service Descriptor.
@@ -36,7 +35,7 @@ public interface ServiceDescriptor extends Serializable {
      * Get the Service name.
      * @return The Service Name.
      */
-    QName getServiceName();
+    String getServiceName();
 
     /**
      * Get the ExchangeHandler.

--- a/bean/src/main/java/org/switchyard/component/bean/internal/SimpleCDIDeployment.java
+++ b/bean/src/main/java/org/switchyard/component/bean/internal/SimpleCDIDeployment.java
@@ -19,11 +19,14 @@
 
 package org.switchyard.component.bean.internal;
 
+import java.util.List;
+
 import javax.xml.namespace.QName;
 
 import org.switchyard.ExchangeHandler;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
+import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.component.bean.deploy.BeanComponentActivator;
 import org.switchyard.component.bean.deploy.BeanDeploymentMetaData;
 import org.switchyard.component.bean.deploy.CDIBean;
@@ -34,9 +37,6 @@ import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.transform.TransformerRegistry;
 import org.switchyard.transform.TransformerTypes;
 import org.switchyard.transform.TransformerUtil;
-
-
-import java.util.List;
 
 /**
  * Simple CDI deployment.
@@ -98,14 +98,15 @@ public class SimpleCDIDeployment extends AbstractDeployment {
         BeanComponentActivator activator = new BeanComponentActivator();
 
         for (ServiceDescriptor serviceDescriptor : beanDeploymentMetaData.getServiceDescriptors()) {
-            QName serviceName = serviceDescriptor.getServiceName();
+            String serviceName = serviceDescriptor.getServiceName();
             ExchangeHandler handler = serviceDescriptor.getHandler();
             ServiceInterface serviceInterface;
             ServiceReference service;
 
             activator.lookupBeanMetaData();
             serviceInterface = activator.buildServiceInterface(serviceName);
-            service = domain.registerService(serviceName, handler, serviceInterface);
+            QName serviceQName = XMLHelper.createQName(domain.getName().getNamespaceURI(), serviceName);
+            service = domain.registerService(serviceQName, handler, serviceInterface);
             activator.start(service);
 
             deployAutoRegisteredTransformers(serviceInterface);

--- a/bean/src/test/resources/jaxbautoregister/switchyard-config-01.xml
+++ b/bean/src/test/resources/jaxbautoregister/switchyard-config-01.xml
@@ -1,10 +1,10 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:jaxbautoregister:orders:1.0">
         <component name="OrderService">
+            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.component.bean.jaxbautoregister.OrderServiceImpl"/>
             <service name="OrderService">
                 <interface.java interface="org.switchyard.component.bean.jaxbautoregister.OrderService"/>
             </service>
-            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.component.bean.jaxbautoregister.OrderServiceImpl"/>
         </component>
     </composite>
 </switchyard>

--- a/bean/src/test/resources/jaxbautoregister/switchyard-config-02.xml
+++ b/bean/src/test/resources/jaxbautoregister/switchyard-config-02.xml
@@ -18,12 +18,12 @@
   -->
 
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:jaxbautoregister:orders:1.0">
         <component name="OrderService">
+            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.component.bean.jaxbautoregister.OrderServiceImpl"/>
             <service name="OrderService">
                 <interface.java interface="org.switchyard.component.bean.jaxbautoregister.OrderService"/>
             </service>
-            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.component.bean.jaxbautoregister.OrderServiceImpl"/>
         </component>
     </composite>
     <transforms>

--- a/bpm/pom.xml
+++ b/bpm/pom.xml
@@ -136,6 +136,20 @@
             <groupId>org.jbpm</groupId>
             <artifactId>jbpm-human-task</artifactId>
             <version>${jbpm.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--
         <dependency>

--- a/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
+++ b/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
@@ -36,8 +36,8 @@ MA  02110-1301, USA.
             <extension base="sca:Implementation">
                 <sequence>
                     <element ref="bpm:processAction" minOccurs="0" maxOccurs="unbounded"/>
-                    <element ref="swyd:resource" minOccurs="0" maxOccurs="unbounded"/>
                     <element ref="bpm:taskHandler" minOccurs="0" maxOccurs="unbounded"/>
+                    <element ref="swyd:resource" minOccurs="0" maxOccurs="unbounded"/>
                 </sequence>
                 <attribute name="processDefinition" type="string" use="required"/>
                 <attribute name="processDefinitionType" type="NCName" use="optional" default="BPMN2"/>

--- a/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BpmModelTests-Complete.xml
+++ b/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BpmModelTests-Complete.xml
@@ -24,8 +24,8 @@ MA  02110-1301, USA.
     <sca:composite name="Foobar" targetNamespace="urn:bpm:test:1.0">
         <sca:component name="FoobarService">
             <bpm:implementation.bpm processDefinition="foobar.bpmn" processDefinitionType="BPMN2" processId="foobar">
-                <swyd:resource location="foobar.drl" type="DRL"/>
                 <bpm:taskHandler class="org.switchyard.component.bpm.task.SwitchYardServiceTaskHandler"/>
+                <swyd:resource location="foobar.drl" type="DRL"/>
             </bpm:implementation.bpm>
             <sca:service name="FoobarService">
                 <sca:interface.java interface="org.test.FoobarService"/>

--- a/camel/camel-core/pom.xml
+++ b/camel/camel-core/pom.xml
@@ -157,6 +157,20 @@
             <artifactId>camel-atom</artifactId>
             <version>${version.camel}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 		
         <dependency>

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/RouteFactory.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/RouteFactory.java
@@ -46,15 +46,35 @@ public final class RouteFactory {
      * @return the route definition
      */
     public static RouteDefinition createRoute(String className) {
-        return createRoute(Classes.forName(className));
+        return createRoute(className, null);
     }
-    
+
+    /**
+     * Create a new route from the given class name and service name.
+     * @param className name of the class containing an @Route definition
+     * @param namespace the namespace to append to switchyard:// service URIs
+     * @return the route definition
+     */
+    public static RouteDefinition createRoute(String className, String namespace) {
+        return createRoute(Classes.forName(className), namespace);
+    }
+
     /**
      * Create a new route from the given class and service name.
      * @param routeClass class containing an @Route definition
      * @return the route definition
      */
     public static RouteDefinition createRoute(Class<?> routeClass) {
+        return createRoute(routeClass, null);
+    }
+
+    /**
+     * Create a new route from the given class and service name.
+     * @param routeClass class containing an @Route definition
+     * @param namespace the namespace to append to switchyard:// service URIs
+     * @return the route definition
+     */
+    public static RouteDefinition createRoute(Class<?> routeClass, String namespace) {
         if (!routeClass.isAnnotationPresent(Route.class)) {
             throw new SwitchYardException("@Route definition is missing on class " 
                     + routeClass.getName());
@@ -76,7 +96,6 @@ public final class RouteFactory {
                     + routeClass.getName(), ex);
         }
         
-        
         // Make sure the generated route is legit
         List<RouteDefinition> routes = builder.getRouteCollection().getRoutes();
         if (routes.isEmpty()) {
@@ -91,7 +110,8 @@ public final class RouteFactory {
             throw new SwitchYardException("Java DSL routes must contain a single 'from' "
                     + routeClass.getName());
         }
-        
+        SwitchYardRouteDefinition.addNamespaceParameter(route, namespace);
         return route;
     }
+
 }

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -19,7 +19,7 @@
 
 package org.switchyard.component.camel;
 
-import static org.switchyard.component.camel.deploy.ComponentNameComposer.componseSwitchYardServiceName;
+import static org.switchyard.component.camel.deploy.ComponentNameComposer.composeSwitchYardServiceName;
 
 import java.util.Set;
 
@@ -55,16 +55,19 @@ import org.switchyard.metadata.java.JavaService;
  */
 public class SwitchYardProducer extends DefaultProducer {
     
+    private String _namespace;
     private String _operationName;
     
     /**
      * Sole constructor.
      * 
      * @param endpoint the Camel Endpoint that this Producer belongs to.
-     * @param operationName the operation name of the target SwitchYard servcie.
+     * @param namespace the service namespace of the target SwitchYard service.
+     * @param operationName the operation name of the target SwitchYard service.
      */
-    public SwitchYardProducer(final Endpoint endpoint, final String operationName) {
+    public SwitchYardProducer(final Endpoint endpoint, final String namespace, final String operationName) {
         super(endpoint);
+        _namespace = namespace;
         _operationName = operationName;
     }
     
@@ -83,7 +86,8 @@ public class SwitchYardProducer extends DefaultProducer {
     }
     
     private ServiceReference lookupServiceReference(final String targetUri) {
-        final ServiceReference serviceRef = ServiceReferences.get(componseSwitchYardServiceName(targetUri));
+        final QName serviceName = composeSwitchYardServiceName(_namespace, targetUri);
+        final ServiceReference serviceRef = ServiceReferences.get(serviceName);
         if (serviceRef == null) {
             throw new NullPointerException("No ServiceReference was found for uri [" + targetUri + "]");
         }

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardRouteDefinition.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardRouteDefinition.java
@@ -1,0 +1,151 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.net.URLEncoder;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.DefaultEndpoint;
+import org.apache.camel.model.FromDefinition;
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.model.ToDefinition;
+import org.switchyard.common.lang.Strings;
+import org.switchyard.common.type.reflect.MethodAccess;
+import org.switchyard.exception.SwitchYardException;
+
+/**
+ * Adds capability of appending a namespace on the end of switchyard:// "from" and "to" URIs.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+public final class SwitchYardRouteDefinition extends RouteDefinition {
+
+    private final String _namespace;
+
+    /**
+     * Constructs a new SwitchYardRouteDefinition with the specified namespace.
+     * @param namespace the specified namespace
+     */
+    public SwitchYardRouteDefinition(String namespace) {
+        super();
+        _namespace = namespace;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RouteDefinition from(String uri) {
+        uri = addNamespaceParameter(uri, _namespace);
+        return super.from(uri);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RouteDefinition to(String uri) {
+        uri = addNamespaceParameter(uri, _namespace);
+        return super.to(uri);
+    }
+
+    /**
+     * Appends a namespace on the end of the specified uri.
+     * @param uri the specified uri
+     * @param namespace the specified namespace
+     * @return the appended uri
+     */
+    public static final String addNamespaceParameter(String uri, String namespace) {
+        if (uri != null && uri.startsWith("switchyard://")) {
+            namespace = Strings.trimToNull(namespace);
+            if (namespace != null) {
+                if (!uri.contains("?namespace=") && !uri.contains("&namespace=")) {
+                    try {
+                        namespace = URLEncoder.encode(namespace, "UTF-8");
+                    } catch (UnsupportedEncodingException uee) {
+                        throw new SwitchYardException(uee);
+                    }
+                    StringBuilder sb = new StringBuilder(uri);
+                    if (uri.indexOf('?') < 0) {
+                        sb.append('?');
+                    } else {
+                        sb.append('&');
+                    }
+                    sb.append("namespace=");
+                    sb.append(namespace);
+                    uri = sb.toString();
+                }
+            }
+        }
+        return uri;
+    }
+
+    /**
+     * Appends a namespace on the end of all URIs found in the specified route.
+     * @param route the specified route
+     * @param namespace the specified namespace
+     */
+    public static final void addNamespaceParameter(RouteDefinition route, String namespace) {
+        for (FromDefinition fromDef : route.getInputs()) {
+            addNamespaceParameterFrom(fromDef, namespace);
+        }
+        for (ProcessorDefinition<?> procDef : route.getOutputs()) {
+            addNamespaceParameterTo(procDef, namespace);
+        }
+    }
+
+    private static final void addNamespaceParameterFrom(FromDefinition fromDef, String namespace) {
+        String old_uri = fromDef.getUri();
+        String new_uri = addNamespaceParameter(old_uri, namespace);
+        fromDef.setUri(new_uri);
+        setEndpointUri(fromDef.getEndpoint(), namespace);
+    }
+
+    private static final void addNamespaceParameterTo(ProcessorDefinition<?> procDef, String namespace) {
+        if (procDef instanceof ToDefinition) {
+            ToDefinition toDef = (ToDefinition)procDef;
+            String old_uri = toDef.getUri();
+            String new_uri = addNamespaceParameter(old_uri, namespace);
+            toDef.setUri(new_uri);
+            setEndpointUri(toDef.getEndpoint(), namespace);
+        }
+        for (ProcessorDefinition<?> procDefChild : procDef.getOutputs()) {
+            addNamespaceParameterTo(procDefChild, namespace);
+        }
+    }
+
+    private static final void setEndpointUri(Endpoint endpoint, String namespace) {
+        if (endpoint instanceof DefaultEndpoint) {
+            String old_uri = endpoint.getEndpointUri();
+            String new_uri = addNamespaceParameter(old_uri, namespace);
+            if (!old_uri.equals(new_uri)) {
+                try {
+                    Method setEndpointUri = DefaultEndpoint.class.getDeclaredMethod("setEndpointUri", new Class[]{String.class});
+                    new MethodAccess<String>(null, setEndpointUri).write((DefaultEndpoint)endpoint, new_uri);
+                } catch (NoSuchMethodException nsfe) {
+                    throw new SwitchYardException(nsfe);
+                }
+            }
+        }
+    }
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchyardComponent.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchyardComponent.java
@@ -41,8 +41,9 @@ public class SwitchyardComponent extends DefaultComponent {
     
     @Override
     protected Endpoint createEndpoint(final String uri, final String path, final Map<String, Object> parameters) throws Exception {
+        final String namespace = (String) parameters.remove("namespace");
         final String operationName = (String) parameters.remove("operationName");
-        return new SwitchyardEndpoint(uri, this, operationName);
+        return new SwitchyardEndpoint(uri, this, namespace, operationName);
     }
     
 }

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchyardEndpoint.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchyardEndpoint.java
@@ -33,6 +33,11 @@ public class SwitchyardEndpoint extends DefaultEndpoint {
     /**
      * Producer property.
      */
+    private String _namespace;
+    
+    /**
+     * Producer property.
+     */
     private String _operationName;
     
     /**
@@ -46,10 +51,12 @@ public class SwitchyardEndpoint extends DefaultEndpoint {
      * 
      * @param endpointUri The uri of the Camel endpoint. 
      * @param component The {@link SwitchyardComponent}.
+     * @param namespace The service namespace that a Producer requires
      * @param operationName The operation name that a Producer requires
      */
-    public SwitchyardEndpoint(final String endpointUri, final SwitchyardComponent component, final String operationName) {
+    public SwitchyardEndpoint(final String endpointUri, final SwitchyardComponent component, final String namespace, final String operationName) {
         super(endpointUri, component);
+        _namespace = namespace;
         _operationName = operationName;
     }
 
@@ -79,7 +86,7 @@ public class SwitchyardEndpoint extends DefaultEndpoint {
 
     @Override
     public Producer createProducer() throws Exception {
-        return new SwitchYardProducer(this, _operationName);
+        return new SwitchYardProducer(this, _namespace, _operationName);
     }
 
     @Override

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/OperationSelector.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/OperationSelector.java
@@ -45,6 +45,11 @@ public abstract class OperationSelector extends BaseModel {
     public static final String DEFAULT_NAMESPACE = "urn:switchyard-component-camel:config:1.0";
     
     /**
+     * The 'namespace' attribute.
+     */
+    public static final String NAMESPACE = "namespace";
+    
+    /**
      * The 'operationName' attribute.
      */
     public static final String OPERATION_NAME = "operationName";
@@ -69,6 +74,20 @@ public abstract class OperationSelector extends BaseModel {
     protected OperationSelector(QName name) {
         super(name);
     }
+
+    /**
+     * Gets the namespace attribute from the underlying model.
+     * 
+     * @return String the content of the namespace attribute.
+     */
+    public abstract String getNamespace();
+    
+    /**
+     * Sets the namespace attribute on the underlying model.
+     * 
+     * @param namespace The operation name.
+     */
+    public abstract void setNamespace(String namespace);
 
     /**
      * Gets the operationName attribute from the underlying model.

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/RouteScanner.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/RouteScanner.java
@@ -64,6 +64,12 @@ public class RouteScanner implements Scanner<SwitchYardModel> {
             ComponentModel componentModel = new V1ComponentModel();
             componentModel.setName(routeClass.getSimpleName());
             
+            // Component implementation definition
+            CamelComponentImplementationModel camelModel = new V1CamelImplementationModel();
+            camelModel.setJavaClass(routeClass.getName());
+            componentModel.setImplementation(camelModel);
+            compositeModel.addComponent(componentModel);
+            
             // Component service definition
             ComponentServiceModel serviceModel = new V1ComponentServiceModel();
             JavaComponentServiceInterfaceModel csiModel = new V1JavaComponentServiceInterfaceModel();
@@ -72,12 +78,6 @@ public class RouteScanner implements Scanner<SwitchYardModel> {
             csiModel.setInterface(serviceInterface.getName());
             serviceModel.setInterface(csiModel);
             componentModel.addService(serviceModel);
-
-            // Component implementation definition
-            CamelComponentImplementationModel camelModel = new V1CamelImplementationModel();
-            camelModel.setJavaClass(routeClass.getName());
-            componentModel.setImplementation(camelModel);
-            compositeModel.addComponent(componentModel);
             
             // Component reference definition(s)
             // Need to add these!

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelImplementationModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelImplementationModel.java
@@ -25,12 +25,12 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
 import org.apache.camel.model.RouteDefinition;
+import org.switchyard.component.camel.SwitchYardRouteDefinition;
 import org.switchyard.component.camel.config.model.CamelComponentImplementationModel;
 import org.switchyard.config.Configuration;
-import org.switchyard.exception.SwitchYardException;
-
 import org.switchyard.config.model.Descriptor;
 import org.switchyard.config.model.composite.v1.V1ComponentImplementationModel;
+import org.switchyard.exception.SwitchYardException;
 
 /**
  * Version 1 implementation.
@@ -69,13 +69,18 @@ public class V1CamelImplementationModel extends V1ComponentImplementationModel i
         if (routeConfig == null) {
             return null;
         }
-        
+        RouteDefinition route;
         try {
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
-            return (RouteDefinition) unmarshaller.unmarshal(routeConfig.getSource());
+            route = (RouteDefinition) unmarshaller.unmarshal(routeConfig.getSource());
         } catch (JAXBException e) {
             throw new SwitchYardException(e);
         }
+        String namespace = getComponent().getTargetNamespace();
+        if (route != null && namespace != null) {
+            SwitchYardRouteDefinition.addNamespaceParameter(route, namespace);
+        }
+        return route;
     }
     
     private static JAXBContext createJAXBInstance() {

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1OperationSelector.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1OperationSelector.java
@@ -33,7 +33,6 @@ import org.switchyard.config.model.Descriptor;
  *
  */
 public class V1OperationSelector extends OperationSelector {
-    private String _operationName;
 
     /**
      * Create a new OperationSelector.
@@ -45,23 +44,37 @@ public class V1OperationSelector extends OperationSelector {
     protected V1OperationSelector(Configuration config, Descriptor desc) {
         super(config, desc);
     }
-    
+
     /**
-     * Sets the operation name on the underlying model.
-     * 
-     * @param operationName Then name of the target operation.
+     * {@inheritDoc}
      */
-    public void setOperationName(String operationName) {
-        setModelAttribute(OPERATION_NAME, operationName);
-        _operationName = operationName;
+    @Override
+    public void setNamespace(String namespace) {
+        setModelAttribute(NAMESPACE, namespace);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getNamespace() {
+        return getModelAttribute(NAMESPACE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setOperationName(String operationName) {
+        setModelAttribute(OPERATION_NAME, operationName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getOperationName() {
-        if (_operationName == null) {
-            _operationName = getModelAttribute(OPERATION_NAME);
-        }
-        return _operationName;
+        return getModelAttribute(OPERATION_NAME);
     }
-    
+
 }

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
@@ -215,11 +215,11 @@ public class CamelActivator extends BaseActivator {
      * corresponding RouteDefinition.
      */
     private RouteDefinition getRouteDefinition(CamelComponentImplementationModel model) {
-        if (model.getRoute() != null) {
-            return model.getRoute();
-        } else {
-            return RouteFactory.createRoute(model.getJavaClass());
+        RouteDefinition routeDef = model.getRoute();
+        if (routeDef == null) {
+            routeDef = RouteFactory.createRoute(model.getJavaClass(), model.getComponent().getTargetNamespace());
         }
+        return routeDef;
     }
 
     private boolean isComponentService(final Model config) {

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/ComponentNameComposer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/ComponentNameComposer.java
@@ -24,6 +24,9 @@ import java.net.URI;
 
 import javax.xml.namespace.QName;
 
+import org.switchyard.common.xml.XMLHelper;
+import org.switchyard.component.camel.SwitchYardRouteDefinition;
+
 /**
  * Utility class that takes care of creating Camel component uris for 
  * SwitchYard services.
@@ -52,19 +55,20 @@ public final class ComponentNameComposer {
     public static String composeComponentUri(final QName serviceName) {
         final StringBuilder sb = new StringBuilder();
         sb.append(SWITCHYARD_COMPONENT_NAME).append("://").append(serviceName.getLocalPart());
-        return sb.toString();
+        return SwitchYardRouteDefinition.addNamespaceParameter(sb.toString(), serviceName.getNamespaceURI());
     }
     
     /**
      * Composes a SwitchYard service name, a QName, from the passed-in string uri.
      * 
+     * @param namespace the service namespace
      * @param uri a string uri.
      * @return QName a SwitchYard service name
      */
-    public static QName componseSwitchYardServiceName(final String uri) {
+    public static QName composeSwitchYardServiceName(final String namespace, final String uri) {
         final URI create = URI.create(uri);
         final String path = create.getAuthority();
-        return new QName(path);
+        return XMLHelper.createQName(namespace, path);
     }
     
 }

--- a/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
+++ b/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
@@ -143,6 +143,7 @@ MA  02110-1301, USA.
     <complexType name="CamelOperationSelectorType">
       <complexContent>
          <extension base="sca:OperationSelectorType">
+             <attribute name="namespace" type="string" use="optional"/>
              <attribute name="operationName" type="string"/>           
          </extension>         
       </complexContent>

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/RouteFactoryTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/RouteFactoryTest.java
@@ -44,7 +44,7 @@ public class RouteFactoryTest {
             RouteFactory.createRoute(NoRouteAnnotation.class.getName());
             Assert.fail("No route annotation on " + NoRouteAnnotation.class.getName());
         } catch (RuntimeException ex) {
-            System.out.println("Route without annotation was rejected: " + ex.toString());
+            System.err.println("Route without annotation was rejected: " + ex.toString());
         }
     }
 
@@ -54,7 +54,7 @@ public class RouteFactoryTest {
             RouteFactory.createRoute(DoesntExtendRouteBuilder.class.getName());
             Assert.fail("Java DSL class does not extend RouteBuilder " + DoesntExtendRouteBuilder.class.getName());
         } catch (RuntimeException ex) {
-            System.out.println("Route class that does not extend RouteBuilder was rejected: " + ex.toString());
+            System.err.println("Route class that does not extend RouteBuilder was rejected: " + ex.toString());
         }
     }
 
@@ -64,7 +64,7 @@ public class RouteFactoryTest {
             RouteFactory.createRoute(NoRoutesDefined.class.getName());
             Assert.fail("No routes defined in Java DSL class " + NoRoutesDefined.class.getName());
         } catch (RuntimeException ex) {
-            System.out.println("Java DSL class without a route was rejected: " + ex.toString());
+            System.err.println("Java DSL class without a route was rejected: " + ex.toString());
         }
     }
 }

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/deploy/CamelActivatorTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/deploy/CamelActivatorTest.java
@@ -78,7 +78,7 @@ public class CamelActivatorTest {
     @Test
     public void startStop() throws Exception {
         final MockHandler mockHandler = _testKit.registerInOnlyService("SimpleCamelService");
-        final ServiceReference serviceRef = _testKit.getServiceDomain().getService(new QName("SimpleCamelService"));
+        final ServiceReference serviceRef = _testKit.getServiceDomain().getService(_testKit.createQName("SimpleCamelService"));
         final CamelActivator activator = getCamelActivator();
         final CamelContext camelContext = activator.getCamelContext();
         final ProducerTemplate producerTemplate = camelContext.createProducerTemplate();

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/deploy/CamelJMSTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/deploy/CamelJMSTest.java
@@ -59,7 +59,7 @@ import org.switchyard.test.mixins.CDIMixIn;
 @SwitchYardTestCaseConfig(config = "switchyard-jms-test.xml", mixins = CDIMixIn.class)
 public class CamelJMSTest {
 
-    private static final QName SERVICE_NAME = new QName("SimpleCamelService");
+    private static final QName SERVICE_NAME = new QName("urn:camel-core:test:1.0", "SimpleCamelService");
 
     private EmbeddedJMS embeddedJMS;
     private SwitchYardTestKit _testKit;

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/direct/v1/switchyard-direct-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/direct/v1/switchyard-direct-binding-beans.xml
@@ -15,7 +15,7 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
 	xmlns:camel="urn:switchyard-component-camel:config:1.0" xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912">
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.direct>
 				<camel:name>fooDirectName</camel:name>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.file>
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-consumer-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-consumer-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.file>
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-producer-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/file/v1/switchyard-file-binding-producer-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.file>
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mock/v1/switchyard-mock-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mock/v1/switchyard-mock-binding-beans.xml
@@ -15,7 +15,7 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
 	xmlns:camel="urn:switchyard-component-camel:config:1.0" xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912">
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.mock>
 				<camel:name>fooMockName</camel:name>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/seda/v1/switchyard-seda-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/seda/v1/switchyard-seda-binding-beans.xml
@@ -15,7 +15,7 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
 	xmlns:camel="urn:switchyard-component-camel:config:1.0" xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912">
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.seda>
 				<camel:name>fooSedaName</camel:name>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/timer/v1/switchyard-timer-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/timer/v1/switchyard-timer-binding-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="SimpleCamelService">
 			<camel:binding.timer>
 			    <camel:name>fooTimer</camel:name>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-binding-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="DirectCamelService">
 			<camel:binding.camel configURI="direct://input">
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-ref-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-ref-beans.xml
@@ -18,7 +18,7 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
     
-    <sca:composite>
+    <sca:composite name="orders" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:reference name="WarehouseService" promote="OrderComponent/WarehouseService">
             <camel:binding.camel configURI="vm://warehouseStatusService"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-direct-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-direct-binding-beans.xml
@@ -17,7 +17,7 @@
     xmlns:camel="urn:switchyard-component-camel:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-	<sca:composite>
+	<sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
 		<sca:service name="camelTest" promote="DirectCamelService">
 			<camel:binding.direct configURI="direct://input">
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-beans.xml
@@ -18,7 +18,7 @@
     xmlns:sd="urn:switchyard-config:switchyard:1.0"
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="orders" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="WarehouseComponent" >
             <bean:implementation.bean class="org.switchyard.component.camel.deploy.support.WarehouseServiceImpl"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-java.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-java.xml
@@ -18,7 +18,7 @@
     xmlns:sd="urn:switchyard-config:switchyard:1.0"
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="SingleRouteService">
             <sca:service name="ServiceInterface" >

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-error.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-error.xml
@@ -18,13 +18,9 @@
     xmlns:sd="urn:switchyard-config:switchyard:1.0"
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="CamelComponent">
-            <sca:service name="OrderService" >
-                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
-            </sca:service>
-            
             <implementation.camel>
                 <route xmlns="http://camel.apache.org/schema/spring" id="CamelTestRoute">
                     <log message="ItemId [${body}]"/>
@@ -32,6 +28,9 @@
                     <log message="Title Name [${body}]"/>
                 </route>
             </implementation.camel>
+            <sca:service name="OrderService" >
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
+            </sca:service>
         </sca:component>
         
     </sca:composite>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-java-dsl.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl-java-dsl.xml
@@ -18,16 +18,20 @@
     xmlns:sd="urn:switchyard-config:switchyard:1.0"
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="WarehouseComponent" >
             <bean:implementation.bean class="org.switchyard.component.camel.deploy.support.WarehouseServiceImpl"/>
-            <sca:service name="WarehouseService" promote="WarehouseService">
+            <sca:service name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:service>
         </sca:component>
     
         <sca:component name="CamelComponent">
+            <implementation.camel>
+                <java class="org.switchyard.component.camel.deploy.support.OrderServiceRoute"/>
+            </implementation.camel>
+            
             <sca:service name="OrderService" >
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
             </sca:service>
@@ -35,10 +39,6 @@
             <sca:reference name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
-            
-            <implementation.camel>
-                <java class="org.switchyard.component.camel.deploy.support.OrderServiceRoute"/>
-            </implementation.camel>
         </sca:component>
         
     </sca:composite>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
@@ -18,16 +18,24 @@
     xmlns:sd="urn:switchyard-config:switchyard:1.0"
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="WarehouseComponent" >
             <bean:implementation.bean class="org.switchyard.component.camel.deploy.support.WarehouseServiceImpl"/>
-            <sca:service name="WarehouseService" promote="WarehouseService">
+            <sca:service name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:service>
         </sca:component>
     
         <sca:component name="CamelComponent">
+            <implementation.camel>
+                <route xmlns="http://camel.apache.org/schema/spring" id="CamelTestRoute">
+                    <log message="ItemId [${body}]"/>
+                    <to uri="switchyard://WarehouseService?operationName=hasItem"/>
+                    <log message="Title Name [${body}]"/>
+                </route>
+            </implementation.camel>
+            
             <sca:service name="OrderService" >
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
             </sca:service>
@@ -36,13 +44,6 @@
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
             
-            <implementation.camel>
-                <route xmlns="http://camel.apache.org/schema/spring" id="Camel Test Route">
-                    <log message="ItemId [${body}]"/>
-                    <to uri="switchyard://WarehouseService?operationName=hasItem"/>
-                    <log message="Title Name [${body}]"/>
-                </route>
-            </implementation.camel>
         </sca:component>
         
     </sca:composite>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-ref.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-ref.xml
@@ -18,9 +18,9 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
     
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:camel-core:test:1.0">
     
-        <sca:reference name="WarehouseService" promote="OrderComponent/WarehouseService">
+        <sca:reference name="WarehouseService" promote="OrderComponent/WarehouseService" multiplicity="1..1">
             <camel:binding.camel configURI="vm://warehouseStatusService"/>
         </sca:reference>
         
@@ -29,7 +29,7 @@
             <sca:service name="OrderService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
             </sca:service>
-            <sca:reference name="WarehouseService">
+            <sca:reference name="WarehouseService" multiplicity="1..1">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
         </sca:component>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-test.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-test.xml
@@ -18,9 +18,9 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="SimpleCamelService" targetNamespace="urn:camel-core:test:1.0">
     
-        <sca:service name="SimpleCamelService">
+        <sca:service name="SimpleCamelService" promote="ComponentName/SimpleCamelService">
             <camel:binding.camel configURI="direct://input"/>
             <camel:binding.camel configURI="direct://input2">
 			    <camel:operationSelector operationName="print"/>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-jms-test.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-jms-test.xml
@@ -18,9 +18,9 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="SimpleCamelService" targetNamespace="urn:camel-core:test:1.0">
     
-        <sca:service name="SimpleCamelService">
+        <sca:service name="SimpleCamelService" promote="ComponentName/SimpleCamelService">
             <camel:binding.camel configURI="jms://TestQueue?connectionFactory=#ConnectionFactory"/>
         </sca:service>
         

--- a/camel/camel-core/src/test/resources/switchyard-configs/cdireg-switchyard.xml
+++ b/camel/camel-core/src/test/resources/switchyard-configs/cdireg-switchyard.xml
@@ -18,15 +18,15 @@
   -->
 
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-service">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-service" targetNamespace="urn:camel-core:test:1.0">
         <service name="JavaDSL" promote="JavaDSLBuilder/JavaDSL"/>
         <component name="JavaDSLBuilder">
-            <service name="JavaDSL">
-                <interface.java interface="org.switchyard.component.camel.cdi.JavaDSL"/>
-            </service>
             <implementation.camel xmlns="urn:switchyard-component-camel:config:1.0">
                 <java class="org.switchyard.component.camel.cdi.JavaDSLBuilder"/>
             </implementation.camel>
+            <service name="JavaDSL">
+                <interface.java interface="org.switchyard.component.camel.cdi.JavaDSL"/>
+            </service>
         </component>
     </composite>
 </switchyard>

--- a/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl-file.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl-file.xml
@@ -17,7 +17,7 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite>
+    <sca:composite targetNamespace="urn:clojure:test:1.0">
         <sca:component name="ClojureComponent">
             <sca:service name="SimpleClojureService">
               <interface></interface>

--- a/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl.xml
@@ -17,7 +17,7 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite>
+    <sca:composite targetNamespace="urn:clojure:test:1.0">
         <sca:component name="ClojureComponent">
             <sca:service name="SimpleClojureService">
               <interface></interface>

--- a/clojure/src/test/resources/org/switchyard/component/clojure/deploy/switchyard-clojure-scriptFile.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/deploy/switchyard-clojure-scriptFile.xml
@@ -17,14 +17,13 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:clojure:test:1.0">
     
         <sca:component name="ClojureComponent">
+            <implementation.clojure injectExchange="true" scriptFile="org/switchyard/component/clojure/deploy/sample.clj"/>
             <sca:service name="OrderService" >
                 <sca:interface.java interface="org.switchyard.component.clojure.deploy.support.OrderService"/>
             </sca:service>
-            
-            <implementation.clojure injectExchange="true" scriptFile="org/switchyard/component/clojure/deploy/sample.clj"/>
         </sca:component>
         
     </sca:composite>

--- a/clojure/src/test/resources/org/switchyard/component/clojure/deploy/switchyard-clojure.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/deploy/switchyard-clojure.xml
@@ -17,13 +17,9 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite>
+    <sca:composite name="OrderService" targetNamespace="urn:clojure:test:1.0">
     
         <sca:component name="ClojureComponent">
-            <sca:service name="OrderService" >
-                <sca:interface.java interface="org.switchyard.component.clojure.deploy.support.OrderService"/>
-            </sca:service>
-            
             <implementation.clojure scriptFile="ordertitle.clj" injectExchange="true">
                 <script>
                     (ns org.switchyard 
@@ -31,6 +27,9 @@
                     (defn process [ex] (.setContent (.getMessage ex) "Fletch") (.getContent (.getMessage ex)))
                 </script>
             </implementation.clojure>
+            <sca:service name="OrderService" >
+                <sca:interface.java interface="org.switchyard.component.clojure.deploy.support.OrderService"/>
+            </sca:service>
         </sca:component>
         
     </sca:composite>

--- a/hornetq/src/main/java/org/switchyard/component/hornetq/deploy/HornetQActivator.java
+++ b/hornetq/src/main/java/org/switchyard/component/hornetq/deploy/HornetQActivator.java
@@ -250,7 +250,7 @@ public class HornetQActivator extends BaseActivator {
                 }
             }
         }
-        final Set<OutboundHandler> outboundHandlers = _refBindings.get(serviceReference);
+        final Set<OutboundHandler> outboundHandlers = _refBindings.get(serviceReference.getName());
         if (outboundHandlers != null) {
             for (OutboundHandler outboundHandler : outboundHandlers) {
                 outboundHandler.stop();

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-all-binding.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-all-binding.xml
@@ -17,7 +17,7 @@
     xmlns:hornetq="urn:switchyard-component-hornetq:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-    <sca:composite>
+    <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
         <sca:service name="hornetQTest" promote="HornetQTestService">
             <hornetq:binding.hornetq>
                 <hornetq:config>

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-binding.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-binding.xml
@@ -17,7 +17,7 @@
     xmlns:hornetq="urn:switchyard-component-hornetq:config:1.0" 
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
 
-    <sca:composite>
+    <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
         <sca:service name="hornetQTest" promote="HornetQTestService">
             <hornetq:binding.hornetq>
                 <hornetq:operationSelector operationName="printIt"/>

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-implementation.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-implementation.xml
@@ -18,7 +18,7 @@
     xmlns:bean="urn:switchyard-component-bean:config:1.0"
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
     
-    <sca:composite>
+    <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
     
         <sca:component name="HornetQComponent">
             <sca:service name="OrderService" >

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/deploy/switchyard-reference-binding-test.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/deploy/switchyard-reference-binding-test.xml
@@ -18,7 +18,7 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
     
         <!-- Reference binding example -->
         <sca:component name="OrderComponent">
@@ -29,7 +29,7 @@
             <sca:reference name="WarehouseService"/>
         </sca:component>
         
-        <sca:reference name="WarehouseService" promote="WarehouseService">
+        <sca:reference name="WarehouseService" promote="WarehouseService" multiplicity="1..1">
             <sca:interface.java interface="org.switchyard.component.hornetq.support.WarehouseService"/>
             <hornetq:binding.hornetq>
 	            <hornetq:operationSelector operationName="processOrder"/>

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/deploy/switchyard-service-binding-test.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/deploy/switchyard-service-binding-test.xml
@@ -18,10 +18,10 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite>
+    <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
     
         <!-- Service binding example -->
-		<sca:service name="HornetQService">
+		<sca:service name="HornetQService" promote="ComponentName/HornetQService">
 	        <hornetq:binding.hornetq>
 	            <hornetq:operationSelector operationName="print"/>
 	            <hornetq:config>

--- a/rules/src/main/java/org/switchyard/component/rules/config/model/RulesSwitchYardScanner.java
+++ b/rules/src/main/java/org/switchyard/component/rules/config/model/RulesSwitchYardScanner.java
@@ -86,15 +86,8 @@ public class RulesSwitchYardScanner implements Scanner<SwitchYardModel> {
                 throw new IOException(rulesInterface.getName() + INTERFACE_ERR_MSG);
             }
             String rulesName = rulesInterface.getSimpleName();
-            JavaComponentServiceInterfaceModel csiModel = new V1JavaComponentServiceInterfaceModel();
-            csiModel.setInterface(rulesInterface.getName());
-            ComponentServiceModel serviceModel = new V1ComponentServiceModel();
-            serviceModel.setInterface(csiModel);
-            serviceModel.setName(rulesName);
             ComponentModel componentModel = new V1ComponentModel();
             componentModel.setName(rulesName);
-            componentModel.addService(serviceModel);
-            compositeModel.addComponent(componentModel);
             RulesComponentImplementationModel rciModel = new V1RulesComponentImplementationModel();
             rciModel.setStateful(rules.stateful());
             JavaService javaService = JavaService.fromClass(rulesInterface);
@@ -121,6 +114,13 @@ public class RulesSwitchYardScanner implements Scanner<SwitchYardModel> {
                 rciModel.addResource(new V1ResourceModel().setLocation(location).setType(type));
             }
             componentModel.setImplementation(rciModel);
+            ComponentServiceModel serviceModel = new V1ComponentServiceModel();
+            JavaComponentServiceInterfaceModel csiModel = new V1JavaComponentServiceInterfaceModel();
+            csiModel.setInterface(rulesInterface.getName());
+            serviceModel.setInterface(csiModel);
+            serviceModel.setName(rulesName);
+            componentModel.addService(serviceModel);
+            compositeModel.addComponent(componentModel);
         }
         return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);
     }

--- a/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
+++ b/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
@@ -35,9 +35,9 @@ MA  02110-1301, USA.
         <complexContent>
             <extension base="sca:Implementation">
                 <sequence>
-                    <element ref="swyd:resource" minOccurs="0" maxOccurs="unbounded"/>
                     <element ref="rules:rulesAction" minOccurs="0" maxOccurs="unbounded"/>
                     <element ref="rules:rulesAudit" minOccurs="0" maxOccurs="1"/>
+                    <element ref="swyd:resource" minOccurs="0" maxOccurs="unbounded"/>
                 </sequence>
                 <attribute name="stateful" type="boolean" use="optional" default="false"/>
                 <attribute name="messageContentName" type="string" use="optional"/>

--- a/rules/src/test/resources/org/switchyard/component/rules/config/model/RulesModelTests-Complete.xml
+++ b/rules/src/test/resources/org/switchyard/component/rules/config/model/RulesModelTests-Complete.xml
@@ -24,9 +24,9 @@ MA  02110-1301, USA.
     <sca:composite name="Foobar" targetNamespace="urn:rules:test:1.0">
         <sca:component name="FoobarService">
             <rules:implementation.rules stateful="true">
+                <rules:rulesAudit interval="2000" log="foobar" type="CONSOLE"/>
                 <swyd:resource location="foo.dsl" type="DSL"/>
                 <swyd:resource location="bar.dslr" type="DSLR"/>
-                <rules:rulesAudit interval="2000" log="foobar" type="CONSOLE"/>
             </rules:implementation.rules>
             <sca:service name="FoobarService">
                 <sca:interface.java interface="org.test.FoobarService"/>

--- a/soap/src/main/resources/org/switchyard/component/soap/config/model/v1/soap-v1.xsd
+++ b/soap/src/main/resources/org/switchyard/component/soap/config/model/v1/soap-v1.xsd
@@ -59,7 +59,7 @@ MA  02110-1301, USA.
                             </documentation>
                         </annotation>
                     </element>
-                    <element name="composer" type="string" minOccurs="0" maxOccurs="1">
+                    <element name="composer" minOccurs="0" maxOccurs="1">
                         <annotation>
                             <documentation>
                                 The fully qualified JAVA Class name for custom composition of SwitchYard Message from SOAP.
@@ -73,7 +73,7 @@ MA  02110-1301, USA.
                                     </documentation>
                                 </annotation>
                             </attribute>
-                            <attribute name="mappedVariableNames" type="QName" use="optional">
+                            <attribute name="mappedVariableNames" type="string" use="optional">
                                 <annotation>
                                     <documentation>
                                         Headers that should be mapped from the request SOAPMessage to the SwitchYard Exchange Context (Scope.IN).
@@ -82,7 +82,7 @@ MA  02110-1301, USA.
                             </attribute>
                         </complexType>
                     </element>
-                    <element name="decomposer" type="string" minOccurs="0" maxOccurs="1">
+                    <element name="decomposer" minOccurs="0" maxOccurs="1">
                         <annotation>
                             <documentation>
                                 The fully qualified JAVA Class name for custom conversion of SwitchYard Message to SOAP.
@@ -96,7 +96,7 @@ MA  02110-1301, USA.
                                     </documentation>
                                 </annotation>
                             </attribute>
-                            <attribute name="mappedVariableNames" type="QName" use="optional">
+                            <attribute name="mappedVariableNames" type="string" use="optional">
                                 <annotation>
                                     <documentation>
                                         Properties that should be mapped from the SwitchYard Exchange Context (Scope.OUT) to the response SOAPMessage.

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
@@ -54,6 +54,7 @@ import org.switchyard.ServiceDomain;
 import org.switchyard.component.soap.config.model.SOAPBindingModel;
 import org.switchyard.component.soap.util.SOAPUtil;
 import org.switchyard.config.model.ModelPuller;
+import org.switchyard.config.model.Validation;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.metadata.BaseService;
@@ -144,13 +145,10 @@ public class SOAPGatewayTest {
         SOAPProvider provider = new SOAPProvider();
 
         CompositeModel composite = _puller.pull("/HelloSwitchYard.xml", getClass());
-        /*
         Validation v = composite.validateModel();
         if (!v.isValid()) {
-            System.err.println("CompositeModel not valid: " + v.getMessage());
-            v.getCause().printStackTrace();
+            throw new Exception("CompositeModel not valid: " + v.getMessage(), v.getCause());
         }
-        */
 
         CompositeServiceModel compositeService = composite.getServices().get(0);
         _config = (SOAPBindingModel)compositeService.getBindings().get(0);

--- a/soap/src/test/resources/DoclitSwitchyard.xml
+++ b/soap/src/test/resources/DoclitSwitchyard.xml
@@ -18,7 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA  02110-1301, USA.
 -->
 <sca:composite xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-           targetNamespace="http://www.jboss.org/switchyard/example/m1app"
+           targetNamespace="urn:soap:test:1.0"
            xmlns:soap="urn:switchyard-component-soap:config:1.0"
            name="m1app">
 

--- a/soap/src/test/resources/HelloSwitchYard.xml
+++ b/soap/src/test/resources/HelloSwitchYard.xml
@@ -18,7 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA  02110-1301, USA.
 -->
 <sca:composite xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-           targetNamespace="http://www.jboss.org/switchyard/example/m1app"
+           targetNamespace="urn:soap:test:1.0"
            xmlns:soap="urn:switchyard-component-soap:config:1.0"
            name="m1app">
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -78,6 +78,20 @@
             <artifactId>milyn-smooks-javabean</artifactId>
             <version>1.5-SNAPSHOT</version>
             <scope>test</scope>
+		    <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xmlParserAPIs</artifactId>
+                </exclusion>
+		    </exclusions>
         </dependency>
 
     </dependencies>

--- a/tests/src/test/java/org/switchyard/component/model/ModelMergeTest.java
+++ b/tests/src/test/java/org/switchyard/component/model/ModelMergeTest.java
@@ -56,7 +56,6 @@ public class ModelMergeTest {
     private void compareToExpected(SwitchYardModel mergedModel) throws IOException {
         StringWriter stringWriter = new StringWriter();
         mergedModel.write(stringWriter);
-//        System.out.println(stringWriter);
         _testKit.compareXMLToResource(stringWriter.toString(), "expected_merged_switchyard.xml");
     }
 }

--- a/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
+++ b/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
@@ -18,8 +18,8 @@
   ~ MA  02110-1301, USA.
   -->
 
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="m1app" targetNamespace="urn:switchyard-quickstarts:m1app:0.1.0-SNAPSHOT">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="m1app">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app" targetNamespace="urn:tests:order:1.0">
         <sca:service xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="OrderService" promote="OrderService">
             <soap:binding.soap xmlns:soap="urn:switchyard-component-soap:config:1.0">
                 <soap:serverPort>18001</soap:serverPort>
@@ -27,19 +27,19 @@
             </soap:binding.soap>
         </sca:service>
         <component name="InventoryService">
-            <service name="InventoryService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.InventoryService"/>
-            </service>
             <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.InventoryServiceBean"/>
+            <service name="InventoryService">
+                <interface.java interface="org.switchyard.quickstarts.m1app.InventoryService"/>
+            </service>
         </component>
         <component name="OrderService">
+            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.OrderServiceBean"/>
             <service name="OrderService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.OrderService"/>
+                <interface.java interface="org.switchyard.quickstarts.m1app.OrderService"/>
             </service>
             <reference name="InventoryService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.InventoryService"/>
+                <interface.java interface="org.switchyard.quickstarts.m1app.InventoryService"/>
             </reference>
-            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.OrderServiceBean"/>
         </component>
     </composite>
     <transforms>

--- a/tests/src/test/resources/org/switchyard/component/model/switchyard_1.xml
+++ b/tests/src/test/resources/org/switchyard/component/model/switchyard_1.xml
@@ -24,13 +24,12 @@
             xmlns:bean="urn:switchyard-component-bean:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstarts:m1app:0.1.0-SNAPSHOT"
             name="m1app">
-    <sca:composite name="m1app">
+    <sca:composite name="m1app" targetNamespace="urn:tests:order:1.0">
         <sca:service name="OrderService" promote="OrderService">
             <soap:binding.soap>
-                <soap:serverPort>18001</soap:serverPort>
                 <soap:wsdl>wsdl/OrderService.wsdl</soap:wsdl>
+                <soap:serverPort>18001</soap:serverPort>
             </soap:binding.soap>
         </sca:service>
     </sca:composite>

--- a/tests/src/test/resources/org/switchyard/component/model/switchyard_2.xml
+++ b/tests/src/test/resources/org/switchyard/component/model/switchyard_2.xml
@@ -19,21 +19,21 @@
   -->
 
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app" targetNamespace="urn:tests:order:1.0">
         <component name="InventoryService">
-            <service name="InventoryService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.InventoryService"/>
-            </service>
             <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.InventoryServiceBean"/>
+            <service name="InventoryService">
+                <interface.java interface="org.switchyard.quickstarts.m1app.InventoryService"/>
+            </service>
         </component>
         <component name="OrderService">
+            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.OrderServiceBean"/>
             <service name="OrderService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.OrderService"/>
+                <interface.java interface="org.switchyard.quickstarts.m1app.OrderService"/>
             </service>
             <reference name="InventoryService">
-                <interface.java xmlns="urn:switchyard-component-bean:config:1.0" interface="org.switchyard.quickstarts.m1app.InventoryService"/>
+                <interface.java interface="org.switchyard.quickstarts.m1app.InventoryService"/>
             </reference>
-            <implementation.bean xmlns="urn:switchyard-component-bean:config:1.0" class="org.switchyard.quickstarts.m1app.OrderServiceBean"/>
         </component>
     </composite>
     <transforms>

--- a/tests/src/test/resources/soap.bindingReference/switchyard.xml
+++ b/tests/src/test/resources/soap.bindingReference/switchyard.xml
@@ -23,10 +23,9 @@ MA  02110-1301, USA.
             xmlns:bean="urn:switchyard-component-bean:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstarts:bindingReference:1.0-SNAPSHOT"
-            name="bindingReference">
-    <sca:composite name="bindingReference" targetNamespace="urn:m1app:example:1.0">
-        <sca:reference name="DummySOAPServiceService">
+            name="soap.bindingReference">
+    <sca:composite name="soap.bindingReference" targetNamespace="urn:switchyard-quickstarts:soap.bindingReference:1.0">
+        <sca:reference multiplicity="1..1" name="DummySOAPServiceService" promote="DummySOAPServiceService">
             <soap:binding.soap>
                 <soap:wsdl>soap.bindingReference/dummyService.wsdl</soap:wsdl>
             </soap:binding.soap>


### PR DESCRIPTION
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()
https://issues.jboss.org/browse/SWITCHYARD-365
