### PR TITLE
SWITCHYARD-406 remove filtering from assembly for bpmn xsds jar

### DIFF
--- a/bpm/assembly.xml
+++ b/bpm/assembly.xml
@@ -15,7 +15,6 @@
     <file>
       <source>target/jbpm-bpmn2-xsds-${jbpm.version}.jar</source>
       <outputDirectory>/modules/org/switchyard/component/bpm/main</outputDirectory>
-      <filtered>true</filtered>
     </file>
     <file>
       <source>src/build/resources/drools/drools-compiler/module.xml</source>


### PR DESCRIPTION
jar is no longer corrupted in switchyard.deployer.zip and as7 release builds without test failures
