### PR TITLE
SWITCHYARD-408: Allow local service name for ServiceName parameter in Swi

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/exchange/drools/DroolsBpmExchangeHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/exchange/drools/DroolsBpmExchangeHandler.java
@@ -56,6 +56,7 @@ import org.switchyard.component.bpm.config.model.TaskHandlerModel;
 import org.switchyard.component.bpm.exchange.BaseBpmExchangeHandler;
 import org.switchyard.component.bpm.task.TaskHandler;
 import org.switchyard.component.bpm.task.drools.DroolsWorkItemHandler;
+import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.metadata.ServiceOperation;
 
 /**
@@ -91,6 +92,8 @@ public class DroolsBpmExchangeHandler extends BaseBpmExchangeHandler {
         if (_messageContentName == null) {
             _messageContentName = MESSAGE_CONTENT_VAR;
         }
+        ComponentModel cm = model.getComponent();
+        String tns = cm != null ? cm.getTargetNamespace() : null;
         for (TaskHandlerModel tihm : model.getTaskHandlers()) {
             TaskHandler tih = Construction.construct(tihm.getClazz());
             String name = tihm.getName();
@@ -98,6 +101,7 @@ public class DroolsBpmExchangeHandler extends BaseBpmExchangeHandler {
                 tih.setName(name);
             }
             tih.setMessageContentName(_messageContentName);
+            tih.setTargetNamespace(tns);
             tih.setServiceDomain(_serviceDomain);
             _taskHandlers.add(tih);
         }

--- a/bpm/src/main/java/org/switchyard/component/bpm/task/BaseTaskHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/task/BaseTaskHandler.java
@@ -29,6 +29,7 @@ public abstract class BaseTaskHandler implements TaskHandler {
 
     private String _name;
     private String _messageContentName;
+    private String _targetNamespace;
     private ServiceDomain _serviceDomain;
 
     /**
@@ -77,6 +78,23 @@ public abstract class BaseTaskHandler implements TaskHandler {
     @Override
     public TaskHandler setMessageContentName(String messageContentName) {
         _messageContentName = messageContentName;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTargetNamespace() {
+        return _targetNamespace;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskHandler setTargetNamespace(String targetNamespace) {
+        _targetNamespace = targetNamespace;
         return this;
     }
 

--- a/bpm/src/main/java/org/switchyard/component/bpm/task/TaskHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/task/TaskHandler.java
@@ -54,6 +54,19 @@ public interface TaskHandler {
     public TaskHandler setMessageContentName(String messageContentName);
 
     /**
+     * Gets the target namespace.
+     * @return the target namespace
+     */
+    public String getTargetNamespace();
+
+    /**
+     * Sets the target namespace.
+     * @param targetNamespace the target namespace
+     * @return this TaskHandler (useful for chaining)
+     */
+    public TaskHandler setTargetNamespace(String targetNamespace);
+
+    /**
      * Gets the ServiceDomain.
      * @return the ServiceDomain
      */


### PR DESCRIPTION
SWITCHYARD-408: Allow local service name for ServiceName parameter in SwitchYardTaskHandler
https://issues.jboss.org/browse/SWITCHYARD-408
