### PR TITLE
SWITCHYARD-423: merged config is not schema valid

### DIFF
--- a/bean/src/test/java/org/switchyard/component/bean/config/model/BeanModelTests.java
+++ b/bean/src/test/java/org/switchyard/component/bean/config/model/BeanModelTests.java
@@ -83,7 +83,7 @@ public class BeanModelTests {
     @Test
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
-        Assert.assertTrue(switchyard.isModelValid());
+        switchyard.assertModelValid();
     }
 
 }

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/BpmComponentImplementationModel.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/BpmComponentImplementationModel.java
@@ -101,19 +101,6 @@ public interface BpmComponentImplementationModel extends ComponentImplementation
     public BpmComponentImplementationModel addProcessAction(ProcessActionModel processAction);
 
     /**
-     * Gets the child resource models.
-     * @return the child resource models
-     */
-    public List<ResourceModel> getResources();
-
-    /**
-     * Adds a child resource model.
-     * @param resource the child resource model
-     * @return this BpmComponentImplementationModel (useful for chaining)
-     */
-    public BpmComponentImplementationModel addResource(ResourceModel resource);
-
-    /**
      * Gets the child task handler models.
      * @return the child task handler models
      */
@@ -125,5 +112,18 @@ public interface BpmComponentImplementationModel extends ComponentImplementation
      * @return this BpmComponentImplementationModel (useful for chaining)
      */
     public BpmComponentImplementationModel addTaskHandler(TaskHandlerModel taskHandler);
+
+    /**
+     * Gets the child resource models.
+     * @return the child resource models
+     */
+    public List<ResourceModel> getResources();
+
+    /**
+     * Adds a child resource model.
+     * @param resource the child resource model
+     * @return this BpmComponentImplementationModel (useful for chaining)
+     */
+    public BpmComponentImplementationModel addResource(ResourceModel resource);
 
 }

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/BpmSwitchYardScanner.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/BpmSwitchYardScanner.java
@@ -147,6 +147,14 @@ public class BpmSwitchYardScanner implements Scanner<SwitchYardModel> {
                     }
                 }
             }
+            bciModel.addTaskHandler(new V1TaskHandlerModel().setClazz(SwitchYardServiceTaskHandler.class).setName(SwitchYardServiceTaskHandler.SWITCHYARD_SERVICE));
+            for (Class<? extends TaskHandler> taskHandlerClass : process.taskHandlers()) {
+                if (Process.UndefinedTaskHandler.class.equals(taskHandlerClass) || SwitchYardServiceTaskHandler.class.equals(taskHandlerClass)) {
+                    continue;
+                }
+                TaskHandler taskHandler = Construction.construct(taskHandlerClass);
+                bciModel.addTaskHandler(new V1TaskHandlerModel().setClazz(taskHandlerClass).setName(taskHandler.getName()));
+            }
             for (Class<? extends Resource> resourceClass : process.resources()) {
                 if (Process.UndefinedResource.class.equals(resourceClass)) {
                     continue;
@@ -155,14 +163,6 @@ public class BpmSwitchYardScanner implements Scanner<SwitchYardModel> {
                 String location = resource.getLocation();
                 ResourceType type = resource.getType();
                 bciModel.addResource(new V1ResourceModel().setLocation(location).setType(type));
-            }
-            bciModel.addTaskHandler(new V1TaskHandlerModel().setClazz(SwitchYardServiceTaskHandler.class).setName(SwitchYardServiceTaskHandler.SWITCHYARD_SERVICE));
-            for (Class<? extends TaskHandler> taskHandlerClass : process.taskHandlers()) {
-                if (Process.UndefinedTaskHandler.class.equals(taskHandlerClass) || SwitchYardServiceTaskHandler.class.equals(taskHandlerClass)) {
-                    continue;
-                }
-                TaskHandler taskHandler = Construction.construct(taskHandlerClass);
-                bciModel.addTaskHandler(new V1TaskHandlerModel().setClazz(taskHandlerClass).setName(taskHandler.getName()));
             }
             componentModel.setImplementation(bciModel);
         }

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BpmComponentImplementationModel.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BpmComponentImplementationModel.java
@@ -46,15 +46,15 @@ import org.switchyard.config.model.resource.ResourceModel;
 public class V1BpmComponentImplementationModel extends V1ComponentImplementationModel implements BpmComponentImplementationModel {
 
     private List<ProcessActionModel> _processActions = new ArrayList<ProcessActionModel>();
-    private List<ResourceModel> _resources = new ArrayList<ResourceModel>();
     private List<TaskHandlerModel> _taskHandlers = new ArrayList<TaskHandlerModel>();
+    private List<ResourceModel> _resources = new ArrayList<ResourceModel>();
 
     /**
      * Default constructor for application use.
      */
     public V1BpmComponentImplementationModel() {
         super(BPM, DEFAULT_NAMESPACE);
-        setModelChildrenOrder(ProcessActionModel.PROCESS_ACTION, ResourceModel.RESOURCE, TaskHandlerModel.TASK_HANDLER);
+        setModelChildrenOrder(ProcessActionModel.PROCESS_ACTION, TaskHandlerModel.TASK_HANDLER, ResourceModel.RESOURCE);
     }
 
     /**
@@ -71,19 +71,19 @@ public class V1BpmComponentImplementationModel extends V1ComponentImplementation
                 _processActions.add(processAction);
             }
         }
-        for (Configuration resource_config : config.getChildren(ResourceModel.RESOURCE)) {
-            ResourceModel resource = (ResourceModel)readModel(resource_config);
-            if (resource != null) {
-                _resources.add(resource);
-            }
-        }
         for (Configuration taskHandler_config : config.getChildren(TaskHandlerModel.TASK_HANDLER)) {
             TaskHandlerModel taskHandler = (TaskHandlerModel)readModel(taskHandler_config);
             if (taskHandler != null) {
                 _taskHandlers.add(taskHandler);
             }
         }
-        setModelChildrenOrder(ProcessActionModel.PROCESS_ACTION, ResourceModel.RESOURCE, TaskHandlerModel.TASK_HANDLER);
+        for (Configuration resource_config : config.getChildren(ResourceModel.RESOURCE)) {
+            ResourceModel resource = (ResourceModel)readModel(resource_config);
+            if (resource != null) {
+                _resources.add(resource);
+            }
+        }
+        setModelChildrenOrder(ProcessActionModel.PROCESS_ACTION, TaskHandlerModel.TASK_HANDLER, ResourceModel.RESOURCE);
     }
 
     /**
@@ -166,24 +166,6 @@ public class V1BpmComponentImplementationModel extends V1ComponentImplementation
      * {@inheritDoc}
      */
     @Override
-    public List<ResourceModel> getResources() {
-        return Collections.unmodifiableList(_resources);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public BpmComponentImplementationModel addResource(ResourceModel resource) {
-        addChildModel(resource);
-        _resources.add(resource);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public List<TaskHandlerModel> getTaskHandlers() {
         return Collections.unmodifiableList(_taskHandlers);
     }
@@ -195,6 +177,24 @@ public class V1BpmComponentImplementationModel extends V1ComponentImplementation
     public BpmComponentImplementationModel addTaskHandler(TaskHandlerModel taskHandler) {
         addChildModel(taskHandler);
         _taskHandlers.add(taskHandler);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<ResourceModel> getResources() {
+        return Collections.unmodifiableList(_resources);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BpmComponentImplementationModel addResource(ResourceModel resource) {
+        addChildModel(resource);
+        _resources.add(resource);
         return this;
     }
 

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/BpmModelTests.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/BpmModelTests.java
@@ -102,7 +102,7 @@ public class BpmModelTests {
     @Test
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
-        Assert.assertTrue(switchyard.isModelValid());
+        switchyard.assertModelValid();
     }
 
     @Test

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-ref.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-ref.xml
@@ -29,7 +29,7 @@
             <sca:service name="OrderService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
             </sca:service>
-            <sca:reference name="WarehouseService" multiplicity="1..1">
+            <sca:reference name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
         </sca:component>

--- a/hornetq/src/test/java/org/switchyard/component/hornetq/config/model/v1/V1HornetQConfigModelTest.java
+++ b/hornetq/src/test/java/org/switchyard/component/hornetq/config/model/v1/V1HornetQConfigModelTest.java
@@ -303,16 +303,16 @@ public class V1HornetQConfigModelTest {
     public void validateModel() throws IOException {
         final HornetQConfigModel bindingModel = pull("hornetq-valid-binding.xml");
         final Validation validation = bindingModel.validateModel();
-        assertThat(validation.getMessage(), is(nullValue()));
+        assertThat(validation.isValid(), is(true));
     }
     
     @Test
     public void programmaticCreation() throws Exception {
         final V1HornetQConfigModel model = new V1HornetQConfigModel();
         model.setCompressLargeMessage(true).setAutoGroup(true).setUseHA(true).setQueue("someQueue");
-        model.toString(); // force the model to be ordered
+        model.orderModelChildren(); // force the model to be ordered
         final Validation validation = model.validateModel();
-        assertThat(validation.getMessage(), is(nullValue()));
+        assertThat(validation.isValid(), is(true));
     }
         
     @Test
@@ -322,7 +322,7 @@ public class V1HornetQConfigModelTest {
         final String xml = model.toString();
         final File savedModel = folder.newFile("hornetq-model.xml");
         final FileWriter fileWriter = new FileWriter(savedModel);
-        model.write(fileWriter, OutputKey.OMIT_XML_DECLARATION);
+        model.write(fileWriter, OutputKey.EXCLUDE_XML_DECLARATION);
         
         final String xmlFromFile = new StringPuller().pull(savedModel);
         XMLUnit.setIgnoreWhitespace(true);

--- a/rules/src/main/java/org/switchyard/component/rules/config/model/RulesComponentImplementationModel.java
+++ b/rules/src/main/java/org/switchyard/component/rules/config/model/RulesComponentImplementationModel.java
@@ -72,19 +72,6 @@ public interface RulesComponentImplementationModel extends ComponentImplementati
     public RulesComponentImplementationModel setMessageContentName(String messageContentName);
 
     /**
-     * Gets the "rulesAudit" child model.
-     * @return the "rulesAudit" child model
-     */
-    public RulesAuditModel getRulesAudit();
-
-    /**
-     * Sets the "rulesAudit" child model.
-     * @param rulesAudit the "rulesAudit" child model
-     * @return this RulesComponentImplementationModel (useful for chaining)
-     */
-    public RulesComponentImplementationModel setRulesAudit(RulesAuditModel rulesAudit);
-
-    /**
      * Gets the child rules action models.
      * @return the child rules action models
      */
@@ -96,6 +83,19 @@ public interface RulesComponentImplementationModel extends ComponentImplementati
      * @return this RulesComponentImplementationModel (useful for chaining)
      */
     public RulesComponentImplementationModel addRulesAction(RulesActionModel rulesAction);
+
+    /**
+     * Gets the "rulesAudit" child model.
+     * @return the "rulesAudit" child model
+     */
+    public RulesAuditModel getRulesAudit();
+
+    /**
+     * Sets the "rulesAudit" child model.
+     * @param rulesAudit the "rulesAudit" child model
+     * @return this RulesComponentImplementationModel (useful for chaining)
+     */
+    public RulesComponentImplementationModel setRulesAudit(RulesAuditModel rulesAudit);
 
     /**
      * Gets the child resource models.

--- a/rules/src/main/java/org/switchyard/component/rules/config/model/v1/V1RulesComponentImplementationModel.java
+++ b/rules/src/main/java/org/switchyard/component/rules/config/model/v1/V1RulesComponentImplementationModel.java
@@ -39,8 +39,8 @@ import org.switchyard.config.model.resource.ResourceModel;
  */
 public class V1RulesComponentImplementationModel extends V1ComponentImplementationModel implements RulesComponentImplementationModel {
 
-    private RulesAuditModel _rulesAudit;
     private List<RulesActionModel> _rulesActions = new ArrayList<RulesActionModel>();
+    private RulesAuditModel _rulesAudit;
     private List<ResourceModel> _resources = new ArrayList<ResourceModel>();
 
     /**
@@ -48,7 +48,7 @@ public class V1RulesComponentImplementationModel extends V1ComponentImplementati
      */
     public V1RulesComponentImplementationModel() {
         super(RULES, DEFAULT_NAMESPACE);
-        setModelChildrenOrder(ResourceModel.RESOURCE, RulesActionModel.RULES_ACTION, RulesAuditModel.RULES_AUDIT);
+        setModelChildrenOrder(RulesActionModel.RULES_ACTION, RulesAuditModel.RULES_AUDIT, ResourceModel.RESOURCE);
     }
 
     /**
@@ -71,7 +71,7 @@ public class V1RulesComponentImplementationModel extends V1ComponentImplementati
                 _resources.add(resource);
             }
         }
-        setModelChildrenOrder(ResourceModel.RESOURCE, RulesActionModel.RULES_ACTION, RulesAuditModel.RULES_AUDIT);
+        setModelChildrenOrder(RulesActionModel.RULES_ACTION, RulesAuditModel.RULES_AUDIT, ResourceModel.RESOURCE);
     }
 
     /**
@@ -113,6 +113,24 @@ public class V1RulesComponentImplementationModel extends V1ComponentImplementati
      * {@inheritDoc}
      */
     @Override
+    public List<RulesActionModel> getRulesActions() {
+        return Collections.unmodifiableList(_rulesActions);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public RulesComponentImplementationModel addRulesAction(RulesActionModel rulesAction) {
+        addChildModel(rulesAction);
+        _rulesActions.add(rulesAction);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public RulesAuditModel getRulesAudit() {
         if (_rulesAudit == null) {
             _rulesAudit = (RulesAuditModel)getFirstChildModelStartsWith(RulesAuditModel.RULES_AUDIT);
@@ -127,24 +145,6 @@ public class V1RulesComponentImplementationModel extends V1ComponentImplementati
     public RulesComponentImplementationModel setRulesAudit(RulesAuditModel rulesAudit) {
         setChildModel(rulesAudit);
         _rulesAudit = rulesAudit;
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public List<RulesActionModel> getRulesActions() {
-        return Collections.unmodifiableList(_rulesActions);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public RulesComponentImplementationModel addRulesAction(RulesActionModel rulesAction) {
-        addChildModel(rulesAction);
-        _rulesActions.add(rulesAction);
         return this;
     }
 

--- a/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
+++ b/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
@@ -99,7 +99,7 @@ public class RulesModelTests {
     @Test
     public void testValidation() throws Exception {
         SwitchYardModel switchyard = _puller.pull(COMPLETE_XML, getClass());
-        Assert.assertTrue(switchyard.isModelValid());
+        switchyard.assertModelValid();
     }
 
     @Test

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
@@ -54,7 +54,6 @@ import org.switchyard.ServiceDomain;
 import org.switchyard.component.soap.config.model.SOAPBindingModel;
 import org.switchyard.component.soap.util.SOAPUtil;
 import org.switchyard.config.model.ModelPuller;
-import org.switchyard.config.model.Validation;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.metadata.BaseService;
@@ -145,10 +144,7 @@ public class SOAPGatewayTest {
         SOAPProvider provider = new SOAPProvider();
 
         CompositeModel composite = _puller.pull("/HelloSwitchYard.xml", getClass());
-        Validation v = composite.validateModel();
-        if (!v.isValid()) {
-            throw new Exception("CompositeModel not valid: " + v.getMessage(), v.getCause());
-        }
+        composite.assertModelValid();
 
         CompositeServiceModel compositeService = composite.getServices().get(0);
         _config = (SOAPBindingModel)compositeService.getBindings().get(0);


### PR DESCRIPTION
SWITCHYARD-423: merged config is not schema valid
https://issues.jboss.org/browse/SWITCHYARD-423
This bubbled out as it exposed places in our models where we don't set the proper order according to the schemas, once validation was also enforced at the post-merge phase of the switchyard configure plugin.
