### PR TITLE
SWITCHYARD-350 fix XML validation errors in development workspace

### DIFF
--- a/bean/src/main/resources/org/switchyard/component/bean/config/model/v1/bean-v1.xsd
+++ b/bean/src/main/resources/org/switchyard/component/bean/config/model/v1/bean-v1.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="implementation.bean" type="bean:BeanImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="BeanImplementationType">

--- a/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
+++ b/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
@@ -24,11 +24,9 @@ MA  02110-1301, USA.
         targetNamespace="urn:switchyard-component-bpm:config:1.0"
         elementFormDefault="qualified">
 
-    <import namespace="urn:switchyard-config:switchyard:1.0"
-            schemaLocation="switchyard-v1.xsd"/>
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="implementation.bpm" type="bpm:BpmImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="BpmImplementationType">

--- a/camel/camel-core/pom.xml
+++ b/camel/camel-core/pom.xml
@@ -21,6 +21,7 @@
         <version.commonman>1.0</version.commonman>
         <version.hornetq>2.2.2.Final</version.hornetq>
         <version.spring>3.0.5.RELEASE</version.spring>
+        <directory.camel.resources>${project.build.directory}/dependency/camel/resources</directory.camel.resources>
     </properties>
 
     <build>
@@ -55,6 +56,52 @@
                     </execution>
                 </executions>
             </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>include-camel-spring-schema</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.apache.camel</groupId>
+                      <artifactId>camel-spring</artifactId>
+                      <version>${version.camel}</version>
+                      <classifier>sources</classifier>
+                      <type>jar</type>
+                      <includes>camel-spring.xsd</includes>
+                      <outputDirectory>${directory.camel.resources}/org/apache/camel/schema/spring</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-resource</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>add-resource</goal>
+                </goals>
+                <configuration>
+                  <resources>
+                    <resource>
+                      <directory>${directory.camel.resources}</directory>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
     </build>
 

--- a/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
+++ b/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
@@ -25,9 +25,9 @@ MA  02110-1301, USA.
         xmlns:camelSpring="http://camel.apache.org/schema/spring"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912" schemaLocation="sca-1.1-cd06.xsd"/>
-    <import namespace="http://www.springframework.org/schema/beans" schemaLocation="spring-beans-2.0.xsd"/>
-    <import namespace="http://camel.apache.org/schema/spring" schemaLocation="camel-spring.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
+    <import namespace="http://www.springframework.org/schema/beans"/>
+    <import namespace="http://camel.apache.org/schema/spring"/>
     
     <!-- camel:binding.xxx -->
     <element name="binding.camel" type="camel:CamelBindingType" substitutionGroup="sca:binding"/>

--- a/camel/camel-core/src/main/resources/org/switchyard/config/model/descriptor.properties
+++ b/camel/camel-core/src/main/resources/org/switchyard/config/model/descriptor.properties
@@ -22,7 +22,7 @@ camel1_0.marshaller=org.switchyard.component.camel.config.model.v1.V1CamelModelM
 
 camel_spring.namespace=http://camel.apache.org/schema/spring
 camel_spring.schema=camel-spring.xsd
-camel_spring.location=/
+camel_spring.location=/org/apache/camel/schema/spring/
 
 spring_beans2_0.namespace=http://www.springframework.org/schema/beans
 spring_beans2_0.schema=spring-beans-2.0.xsd

--- a/camel/camel-core/src/test/resources/hornetq-configuration.xml
+++ b/camel/camel-core/src/test/resources/hornetq-configuration.xml
@@ -1,6 +1,4 @@
- <configuration xmlns="urn:hornetq"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="urn:hornetq http://schema/hornetq-configuration.xsd">
+ <configuration xmlns="urn:hornetq">
                
 	<paging-directory>target/data/paging</paging-directory>
 	<bindings-directory>target/data/bindings</bindings-directory>

--- a/camel/camel-core/src/test/resources/hornetq-jms.xml
+++ b/camel/camel-core/src/test/resources/hornetq-jms.xml
@@ -1,6 +1,4 @@
-<configuration xmlns="urn:hornetq"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:hornetq http://schema/hornetq-jms.xsd">
+<configuration xmlns="urn:hornetq">
 
    <connection-factory name="ConnectionFactory">
       <connectors>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-ref-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-camel-ref-beans.xml
@@ -20,7 +20,7 @@
     
     <sca:composite name="orders" targetNamespace="urn:camel-core:test:1.0">
     
-        <sca:reference name="WarehouseService" promote="OrderComponent/WarehouseService">
+        <sca:reference name="WarehouseService" promote="OrderComponent/WarehouseService" multiplicity="1..1">
             <camel:binding.camel configURI="vm://warehouseStatusService"/>
         </sca:reference>
         

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-beans.xml
@@ -22,20 +22,12 @@
     
         <sca:component name="WarehouseComponent" >
             <bean:implementation.bean class="org.switchyard.component.camel.deploy.support.WarehouseServiceImpl"/>
-            <sca:service name="WarehouseService" promote="WarehouseService">
+            <sca:service name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:service>
         </sca:component>
     
         <sca:component name="CamelComponent">
-            <sca:service name="OrderService" >
-                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
-            </sca:service>
-            
-            <sca:reference name="WarehouseService">
-                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
-            </sca:reference>
-            
             <implementation.camel>
                 <route xmlns="http://camel.apache.org/schema/spring" id="CamelTestRoute">
                     <log message="ItemId [${body}]"/>
@@ -43,6 +35,14 @@
                     <log message="Title Name [${body}]"/>
                 </route>
             </implementation.camel>
+
+            <sca:service name="OrderService" >
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.OrderService"/>
+            </sca:service>
+            
+            <sca:reference name="WarehouseService">
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
+            </sca:reference>
         </sca:component>
         
     </sca:composite>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-java.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/v1/switchyard-implementation-java.xml
@@ -21,13 +21,13 @@
     <sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
     
         <sca:component name="SingleRouteService">
-            <sca:service name="ServiceInterface" >
-                <sca:interface.java interface="org.switchyard.component.camel.config.model.ServiceInterface"/>
-            </sca:service>
-            
             <implementation.camel>
                 <java class="org.switchyard.component.camel.config.model.SingleRouteService"/>
             </implementation.camel>
+
+            <sca:service name="ServiceInterface" >
+                <sca:interface.java interface="org.switchyard.component.camel.config.model.ServiceInterface"/>
+            </sca:service>
         </sca:component>
         
         

--- a/clojure/src/main/resources/org/switchyard/component/clojure/config/model/v1/clojure-v1.xsd
+++ b/clojure/src/main/resources/org/switchyard/component/clojure/config/model/v1/clojure-v1.xsd
@@ -23,7 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912" schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
     
     <!--  clojure:implementation.clojure -->
     <element name="implementation.clojure" type="clojure:ClojureImplementationType" substitutionGroup="sca:implementation"/>

--- a/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl-file.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl-file.xml
@@ -17,15 +17,13 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite targetNamespace="urn:clojure:test:1.0">
+    <sca:composite name="switchyard-clojure-impl-file" targetNamespace="urn:clojure:test:1.0">
         <sca:component name="ClojureComponent">
+            <implementation.clojure injectExchange="true" scriptFile="sample.clj"/>
             <sca:service name="SimpleClojureService">
-              <interface></interface>
             </sca:service>
             <sca:reference name="OtherService">
-              <interface></interface>
             </sca:reference>
-            <implementation.clojure injectExchange="true" scriptFile="sample.clj"/>
         </sca:component>
     </sca:composite>
 

--- a/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl.xml
+++ b/clojure/src/test/resources/org/switchyard/component/clojure/config/model/v1/switchyard-clojure-impl.xml
@@ -17,17 +17,15 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:sd="urn:switchyard-config:switchyard:1.0">
 
-    <sca:composite targetNamespace="urn:clojure:test:1.0">
+    <sca:composite name="switchyard-clojure-impl" targetNamespace="urn:clojure:test:1.0">
         <sca:component name="ClojureComponent">
-            <sca:service name="SimpleClojureService">
-              <interface></interface>
-            </sca:service>
-            <sca:reference name="OtherService">
-              <interface></interface>
-            </sca:reference>
             <implementation.clojure>
                 <script>(ns printer)(defn print-string [arg] (println arg))</script>
             </implementation.clojure>
+            <sca:service name="SimpleClojureService">
+            </sca:service>
+            <sca:reference name="OtherService">
+            </sca:reference>
         </sca:component>
     </sca:composite>
 

--- a/hornetq/src/main/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-v1.xsd
+++ b/hornetq/src/main/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-v1.xsd
@@ -24,7 +24,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <xsd:import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912" schemaLocation="sca-1.1-cd06.xsd"/>
+    <xsd:import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
     
     <xsd:element name="binding.hornetq" type="hornetq:BindingType" substitutionGroup="sca:binding"/>
     <xsd:complexType name="BindingType" >

--- a/hornetq/src/test/resources/hornetq-configuration.xml
+++ b/hornetq/src/test/resources/hornetq-configuration.xml
@@ -1,6 +1,4 @@
- <configuration xmlns="urn:hornetq"
-               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="urn:hornetq http://schema/hornetq-configuration.xsd">
+ <configuration xmlns="urn:hornetq">
                
 	<paging-directory>target/data/paging</paging-directory>
 	<bindings-directory>target/data/bindings</bindings-directory>

--- a/hornetq/src/test/resources/hornetq-jms.xml
+++ b/hornetq/src/test/resources/hornetq-jms.xml
@@ -1,6 +1,4 @@
-<configuration xmlns="urn:hornetq"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:hornetq http://schema/hornetq-jms.xsd">
+<configuration xmlns="urn:hornetq">
 
    <connection-factory name="ConnectionFactory">
       <connectors>

--- a/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-implementation.xml
+++ b/hornetq/src/test/resources/org/switchyard/component/hornetq/config/model/v1/hornetq-valid-implementation.xml
@@ -21,49 +21,49 @@
     <sca:composite name="hornetQTest" targetNamespace="urn:hornetq:test:1.0">
     
         <sca:component name="HornetQComponent">
+            <hornetq:implementation.hornetq>
+                <hornetq:config>
+                  <hornetq:ackBatchSize>200</hornetq:ackBatchSize>
+                  <hornetq:autoGroup>true</hornetq:autoGroup>
+                  <hornetq:blockOnAcknowledge>true</hornetq:blockOnAcknowledge>
+                  <hornetq:blockOnDurableSend>false</hornetq:blockOnDurableSend>
+                  <hornetq:blockOnNonDurableSend>true</hornetq:blockOnNonDurableSend>
+                  <hornetq:cacheLargeMessagesOnConsumer>true</hornetq:cacheLargeMessagesOnConsumer>
+                  <hornetq:callTimeout>3000</hornetq:callTimeout>
+                  <hornetq:clientFailureCheckPeriod>2050</hornetq:clientFailureCheckPeriod>
+                  <hornetq:compressLargeMessages>true</hornetq:compressLargeMessages>
+                  <hornetq:connectionLoadBalancingPolicyClassName>Mock</hornetq:connectionLoadBalancingPolicyClassName>
+                  <hornetq:connectionTTL>1000</hornetq:connectionTTL>
+                  <hornetq:confirmationWindowSize>2</hornetq:confirmationWindowSize>
+                  <hornetq:connector>
+                     <hornetq:factoryClass>org.test.Connector</hornetq:factoryClass>
+                  </hornetq:connector>
+                  <hornetq:consumerMaxRate>10</hornetq:consumerMaxRate>
+                  <hornetq:consumerWindowSize>2000</hornetq:consumerWindowSize>
+                  <hornetq:disableFinalizeCheck>true</hornetq:disableFinalizeCheck>
+                  <hornetq:failoverOnInitialConnection>false</hornetq:failoverOnInitialConnection>
+                  <hornetq:groupID>testGroup</hornetq:groupID>
+                  <hornetq:initialMessagePacketSize>2500</hornetq:initialMessagePacketSize>
+                  <hornetq:initialReconnectAttempts>3</hornetq:initialReconnectAttempts>
+                  <hornetq:maxRetryInterval>500</hornetq:maxRetryInterval>
+                  <hornetq:minLargeMessageSize>5000</hornetq:minLargeMessageSize>
+                  <hornetq:preAcknowledge>true</hornetq:preAcknowledge>
+                  <hornetq:producerMaxRate>20</hornetq:producerMaxRate>
+                  <hornetq:producerWindowSize>100</hornetq:producerWindowSize>
+                  <hornetq:queue>testQueue</hornetq:queue>
+                  <hornetq:reconnectAttempts>2</hornetq:reconnectAttempts>
+                  <hornetq:retryInterval>5000</hornetq:retryInterval>
+                  <hornetq:retryIntervalMultiplier>500.0</hornetq:retryIntervalMultiplier>
+                  <hornetq:scheduledThreadPoolMaxSize>10</hornetq:scheduledThreadPoolMaxSize>
+                  <hornetq:threadPoolMaxSize>5</hornetq:threadPoolMaxSize>
+                  <hornetq:useGlobalPools>true</hornetq:useGlobalPools>
+                  <hornetq:useHA>true</hornetq:useHA>
+                </hornetq:config>
+            </hornetq:implementation.hornetq>
+
             <sca:service name="OrderService" >
                 <sca:interface.java interface="org.switchyard.component.hornetq.support.HornetQService"/>
             </sca:service>
-            
-            <hornetq:implementation.hornetq>
-                <hornetq:config>
-	                <hornetq:ackBatchSize>200</hornetq:ackBatchSize>
-	                <hornetq:autoGroup>true</hornetq:autoGroup>
-	                <hornetq:blockOnAcknowledge>true</hornetq:blockOnAcknowledge>
-	                <hornetq:blockOnDurableSend>false</hornetq:blockOnDurableSend>
-	                <hornetq:blockOnNonDurableSend>true</hornetq:blockOnNonDurableSend>
-	                <hornetq:cacheLargeMessagesOnConsumer>true</hornetq:cacheLargeMessagesOnConsumer>
-	                <hornetq:callTimeout>3000</hornetq:callTimeout>
-	                <hornetq:clientFailureCheckPeriod>2050</hornetq:clientFailureCheckPeriod>
-	                <hornetq:compressLargeMessages>true</hornetq:compressLargeMessages>
-	                <hornetq:connectionLoadBalancingPolicyClassName>Mock</hornetq:connectionLoadBalancingPolicyClassName>
-	                <hornetq:connectionTTL>1000</hornetq:connectionTTL>
-	                <hornetq:confirmationWindowSize>2</hornetq:confirmationWindowSize>
-	                <hornetq:connector>
-	                   <hornetq:factoryClass>org.test.Connector</hornetq:factoryClass>
-	                </hornetq:connector>
-	                <hornetq:consumerMaxRate>10</hornetq:consumerMaxRate>
-	                <hornetq:consumerWindowSize>2000</hornetq:consumerWindowSize>
-	                <hornetq:disableFinalizeCheck>true</hornetq:disableFinalizeCheck>
-	                <hornetq:failoverOnInitialConnection>false</hornetq:failoverOnInitialConnection>
-	                <hornetq:groupID>testGroup</hornetq:groupID>
-	                <hornetq:initialMessagePacketSize>2500</hornetq:initialMessagePacketSize>
-	                <hornetq:initialReconnectAttempts>3</hornetq:initialReconnectAttempts>
-	                <hornetq:maxRetryInterval>500</hornetq:maxRetryInterval>
-	                <hornetq:minLargeMessageSize>5000</hornetq:minLargeMessageSize>
-	                <hornetq:preAcknowledge>true</hornetq:preAcknowledge>
-	                <hornetq:producerMaxRate>20</hornetq:producerMaxRate>
-	                <hornetq:producerWindowSize>100</hornetq:producerWindowSize>
-	                <hornetq:queue>testQueue</hornetq:queue>
-	                <hornetq:reconnectAttempts>2</hornetq:reconnectAttempts>
-	                <hornetq:retryInterval>5000</hornetq:retryInterval>
-	                <hornetq:retryIntervalMultiplier>500.0</hornetq:retryIntervalMultiplier>
-	                <hornetq:scheduledThreadPoolMaxSize>10</hornetq:scheduledThreadPoolMaxSize>
-	                <hornetq:threadPoolMaxSize>5</hornetq:threadPoolMaxSize>
-	                <hornetq:useGlobalPools>true</hornetq:useGlobalPools>
-	                <hornetq:useHA>true</hornetq:useHA>
-                </hornetq:config>
-            </hornetq:implementation.hornetq>
         </sca:component>
     </sca:composite>
 

--- a/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
+++ b/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
@@ -24,11 +24,9 @@ MA  02110-1301, USA.
         targetNamespace="urn:switchyard-component-rules:config:1.0"
         elementFormDefault="qualified">
 
-    <import namespace="urn:switchyard-config:switchyard:1.0"
-            schemaLocation="switchyard-v1.xsd"/>
+    <import namespace="urn:switchyard-config:switchyard:1.0"/>
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="implementation.rules" type="rules:RulesImplementationType" substitutionGroup="sca:implementation"/>
     <complexType name="RulesImplementationType">

--- a/soap/src/main/resources/org/switchyard/component/soap/config/model/v1/soap-v1.xsd
+++ b/soap/src/main/resources/org/switchyard/component/soap/config/model/v1/soap-v1.xsd
@@ -23,8 +23,7 @@ MA  02110-1301, USA.
         xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
         elementFormDefault="qualified">
 
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
     <element name="binding.soap" type="soap:SOAPBindingType" substitutionGroup="sca:binding"/>
     <complexType name="SOAPBindingType">

--- a/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
+++ b/tests/src/test/resources/org/switchyard/component/model/expected_merged_switchyard.xml
@@ -22,8 +22,8 @@
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="m1app" targetNamespace="urn:tests:order:1.0">
         <sca:service xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="OrderService" promote="OrderService">
             <soap:binding.soap xmlns:soap="urn:switchyard-component-soap:config:1.0">
-                <soap:serverPort>18001</soap:serverPort>
                 <soap:wsdl>wsdl/OrderService.wsdl</soap:wsdl>
+                <soap:serverPort>18001</soap:serverPort>
             </soap:binding.soap>
         </sca:service>
         <component name="InventoryService">


### PR DESCRIPTION
remove schemaLocation attributes from schema definitions.
fixed most validation errors.

associated with core: https://github.com/jboss-switchyard/core/pull/290
