### PR TITLE
SWITCHYARD-474 - update to use the new deployment interface that supports

### DIFF
--- a/bpel/src/main/java/org/switchyard/component/bpel/config/model/BPELComponentImplementationModel.java
+++ b/bpel/src/main/java/org/switchyard/component/bpel/config/model/BPELComponentImplementationModel.java
@@ -51,19 +51,4 @@ public interface BPELComponentImplementationModel extends ComponentImplementatio
      */
     public BPELComponentImplementationModel setProcess(String process);
 
-    /**
-     * Gets the "version" attribute.
-     *
-     * @return the "version" attribute
-     */
-    public String getVersion();
-
-    /**
-     * Sets the "version" attribute.
-     *
-     * @param version the "version" attribute
-     * @return this instance (useful for chaining)
-     */
-    public BPELComponentImplementationModel setVersion(String version);
-
 }

--- a/bpel/src/main/java/org/switchyard/component/bpel/config/model/v1/V1BPELComponentImplementationModel.java
+++ b/bpel/src/main/java/org/switchyard/component/bpel/config/model/v1/V1BPELComponentImplementationModel.java
@@ -19,7 +19,6 @@
 package org.switchyard.component.bpel.config.model.v1;
 
 import static org.switchyard.component.bpel.process.ProcessConstants.PROCESS;
-import static org.switchyard.component.bpel.process.ProcessConstants.VERSION;
 
 import org.switchyard.component.bpel.config.model.BPELComponentImplementationModel;
 import org.switchyard.config.Configuration;
@@ -64,24 +63,4 @@ public class V1BPELComponentImplementationModel extends V1ComponentImplementatio
         return this;
     }
     
-    /**
-     * Gets the "version" attribute.
-     *
-     * @return the "version" attribute
-     */
-    public String getVersion() {
-        return getModelAttribute(VERSION);
-    }
-
-    /**
-     * Sets the "version" attribute.
-     *
-     * @param version the "version" attribute
-     * @return this instance (useful for chaining)
-     */
-    public BPELComponentImplementationModel setVersion(String version) {
-        setModelAttribute(VERSION, version);
-        return this;
-    }
-
 }

--- a/bpel/src/main/java/org/switchyard/component/bpel/process/ProcessConstants.java
+++ b/bpel/src/main/java/org/switchyard/component/bpel/process/ProcessConstants.java
@@ -40,10 +40,4 @@ public final class ProcessConstants {
     /** {http://docs.oasis-open.org/ns/opencsa/sca/200903}process . */
     public static final String PROCESS_VAR = new QName(PROCESS_NAMESPACE, PROCESS).toString();
 
-    /** version . */
-    public static final String VERSION = "version";
-    
-    /** {http://docs.oasis-open.org/ns/opencsa/sca/200903}version . */
-    public static final String VERSION_VAR = new QName(PROCESS_NAMESPACE, VERSION).toString();
-
 }


### PR DESCRIPTION
SWITCHYARD-474 - update to use the new deployment interface that supports versioning, and remove the 'version' attribute from the BPEL component model
