### PR TITLE
SWITCHYARD-464: Add default operation to generated service interface for 

### DIFF
--- a/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
+++ b/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
@@ -126,6 +126,10 @@ public class BPMServicePlugin implements Plugin {
                 .setPackage(pkgName)
                 .setName(argServiceName)
                 .setPublic();
+
+            // Add a default process method...
+            processInterface.addMethod("void process(String content);");
+
             java.saveJavaSource(processInterface);
             interfaceClass = processInterface.getQualifiedName();
 


### PR DESCRIPTION
SWITCHYARD-464: Add default operation to generated service interface for BPM services

https://issues.jboss.org/browse/SWITCHYARD-464
