### PR TITLE
SWITCHYARD-469 scanners should not add composite if no components were added

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
+++ b/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
@@ -65,7 +65,6 @@ public class BeanSwitchYardScanner implements Scanner<SwitchYardModel> {
         SwitchYardModel switchyardModel = new V1SwitchYardModel();
         CompositeModel compositeModel = new V1CompositeModel();
         compositeModel.setName(input.getName());
-        switchyardModel.setComposite(compositeModel);
 
         List<Class<?>> serviceClasses = scanForServiceBeans(input.getURLs());
 
@@ -119,6 +118,10 @@ public class BeanSwitchYardScanner implements Scanner<SwitchYardModel> {
             compositeModel.addComponent(componentModel);
             componentModel.setName(name);
             compositeModel.addComponent(componentModel);
+        }
+
+        if (!compositeModel.getModelChildren().isEmpty()) {
+            switchyardModel.setComposite(compositeModel);
         }
 
         return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);

--- a/bean/src/test/java/org/switchyard/component/bean/config/model/BeanSwitchYardScannerTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/config/model/BeanSwitchYardScannerTest.java
@@ -20,10 +20,10 @@
 package org.switchyard.component.bean.config.model;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Assert;
@@ -45,22 +45,23 @@ import org.switchyard.config.model.switchyard.SwitchYardModel;
 public class BeanSwitchYardScannerTest {
     
     private SwitchYardModel _scannedModel;
+    private BeanSwitchYardScanner _scanner;
+    private List<URL> _scannedURLs;
     
     @Before
     public void setUp() throws Exception {
-        BeanSwitchYardScanner scanner = new BeanSwitchYardScanner();
-        List<URL> urls = new ArrayList<URL>();
+        _scanner = new BeanSwitchYardScanner();
 
         // If running this test inside your IDE... you need to set the cwd to be the
         // root of the bean module !!
-        urls.add(new File("./target/test-classes").toURI().toURL());
+        _scannedURLs = new ArrayList<URL>();
+        _scannedURLs.add(new File("./target/test-classes").toURI().toURL());
 
-        ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>().setURLs(urls);
-        _scannedModel = scanner.scan(input).getModel();
     }
 
     @Test
-    public void test() throws IOException, ClassNotFoundException {
+    public void test() throws Exception {
+        scan(new File("./target/test-classes").toURI().toURL());
         List<ComponentModel> components = _scannedModel.getComposite().getComponents();
         for(ComponentModel component : components) {
             ComponentImplementationModel implementation = component.getImplementation();
@@ -72,6 +73,7 @@ public class BeanSwitchYardScannerTest {
     // Verify that the ConsumerBean reference is picked up by the scanner
     @Test
     public void checkReference() throws Exception {
+        scan(new File("./target/test-classes").toURI().toURL());
         ComponentModel consumerBeanModel = null;
         ComponentReferenceModel oneWayReference = null;
         
@@ -94,11 +96,29 @@ public class BeanSwitchYardScannerTest {
         Assert.assertNotNull(oneWayReference);
     }
     
+    // verify an empty model is created
+    @Test
+    public void testEmptyScan() throws Exception {
+        scan();
+        Assert.assertNull("Composite element should not be created if no components were found.",
+                _scannedModel.getComposite());
+    }
+
     private void checkBeanModel(BeanComponentImplementationModel model) throws ClassNotFoundException {
         Class<?> serviceClass = Classes.forName(model.getClazz(), getClass());
 
         Assert.assertFalse(serviceClass.isInterface());
         Assert.assertFalse(Modifier.isAbstract(serviceClass.getModifiers()));
         Assert.assertTrue(serviceClass.isAnnotationPresent(Service.class));
+    }
+    
+    // Takes a list of URLs to scan *instead* of what's defined in @Before.
+    private void scan(URL ... urls) throws Exception {
+        _scannedURLs.clear();
+        if (urls != null && urls.length > 0) {
+            _scannedURLs.addAll(Arrays.asList(urls));
+        }
+        ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>().setURLs(_scannedURLs);
+        _scannedModel = _scanner.scan(input).getModel();
     }
 }

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/BPMModelTests.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/BPMModelTests.java
@@ -152,4 +152,13 @@ public class BPMModelTests {
         }
     }
 
+    @Test
+    public void testEmptyScan() throws Exception {
+        Scanner<SwitchYardModel> scanner = new BPMSwitchYardScanner();
+        ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>();
+        ScannerOutput<SwitchYardModel> output = scanner.scan(input);
+        Assert.assertNull("Composite element should not be created if no components were found.", output.getModel()
+                .getComposite());
+    }
+
 }

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/RouteScanner.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/RouteScanner.java
@@ -54,7 +54,6 @@ public class RouteScanner implements Scanner<SwitchYardModel> {
         SwitchYardModel switchyardModel = new V1SwitchYardModel();
         CompositeModel compositeModel = new V1CompositeModel();
         compositeModel.setName(input.getName());
-        switchyardModel.setComposite(compositeModel);
 
         List<Class<?>> routeClasses = scanForRoutes(input.getURLs());
 
@@ -83,6 +82,10 @@ public class RouteScanner implements Scanner<SwitchYardModel> {
             // Need to add these!
         }
         
+        if (!compositeModel.getModelChildren().isEmpty()) {
+            switchyardModel.setComposite(compositeModel);
+        }
+
         return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);
     }
 

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/RouteScannerTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/RouteScannerTest.java
@@ -20,6 +20,7 @@
 package org.switchyard.component.camel.config.model;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
@@ -58,7 +59,7 @@ public class RouteScannerTest {
 
     @Test
     public void componentImplementationCreated() throws Exception {
-        scan(new File("./target/test-classes/org/switchyard/component/camel/config/model").toURI().toURL());
+        scan(new URL(new File("./target/test-classes").toURI().toURL(), "#org/switchyard/component/camel/config/model"));
         List<ComponentModel> components = _scannedModel.getComposite().getComponents();
         for(ComponentModel component : components) {
             System.out.println("RouteScanner found component: " + component.getName());
@@ -71,6 +72,14 @@ public class RouteScannerTest {
         }
     }
     
+    // verify an empty model is created
+    @Test
+    public void testEmptyScan() throws Exception {
+        scan();
+        Assert.assertNull("Composite element should not be created if no components were found.",
+                _scannedModel.getComposite());
+    }
+
     private void checkCamelImplementation(CamelComponentImplementationModel model) throws Exception {
         // Load the class
         Class<?> routeClass = Classes.forName(model.getJavaClass(), getClass());
@@ -82,8 +91,8 @@ public class RouteScannerTest {
     
     // Takes a list of URLs to scan *instead* of what's defined in @Before.
     private void scan(URL ... urls) throws Exception {
+        _scannedURLs.clear();
         if (urls != null && urls.length > 0) {
-            _scannedURLs.clear();
             _scannedURLs.addAll(Arrays.asList(urls));
         }
         ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>().setURLs(_scannedURLs);

--- a/rules/src/main/java/org/switchyard/component/rules/config/model/RulesSwitchYardScanner.java
+++ b/rules/src/main/java/org/switchyard/component/rules/config/model/RulesSwitchYardScanner.java
@@ -66,13 +66,14 @@ import org.switchyard.metadata.java.JavaService;
  */
 public class RulesSwitchYardScanner implements Scanner<SwitchYardModel> {
 
-    private static final IsAnnotationPresentFilter RULES_FILTER = new IsAnnotationPresentFilter(Rules.class);
     private static final IsAnnotationPresentFilter EXECUTE_FILTER = new IsAnnotationPresentFilter(Execute.class);
     private static final IsAnnotationPresentFilter FIRE_ALL_RULES_FILTER = new IsAnnotationPresentFilter(FireAllRules.class);
     private static final IsAnnotationPresentFilter FIRE_UNTIL_HALT_FILTER = new IsAnnotationPresentFilter(FireUntilHalt.class);
 
     private static final String UNDEFINED = "";
     private static final String INTERFACE_ERR_MSG = " is a class. @Rules only allowed on interfaces.";
+
+    private final IsAnnotationPresentFilter _rulesFilter = new IsAnnotationPresentFilter(Rules.class);
 
     /**
      * {@inheritDoc}
@@ -82,12 +83,11 @@ public class RulesSwitchYardScanner implements Scanner<SwitchYardModel> {
         SwitchYardModel switchyardModel = new V1SwitchYardModel();
         CompositeModel compositeModel = new V1CompositeModel();
         compositeModel.setName(input.getName());
-        switchyardModel.setComposite(compositeModel);
-        ClasspathScanner rulesScanner = new ClasspathScanner(RULES_FILTER);
+        ClasspathScanner rulesScanner = new ClasspathScanner(_rulesFilter);
         for (URL url : input.getURLs()) {
             rulesScanner.scan(url);
         }
-        List<Class<?>> rulesClasses = RULES_FILTER.getMatchedTypes();
+        List<Class<?>> rulesClasses = _rulesFilter.getMatchedTypes();
         for (Class<?> rulesClass : rulesClasses) {
             Rules rules = rulesClass.getAnnotation(Rules.class);
             Class<?> rulesInterface = rules.value();
@@ -183,6 +183,11 @@ public class RulesSwitchYardScanner implements Scanner<SwitchYardModel> {
             componentModel.addService(serviceModel);
             compositeModel.addComponent(componentModel);
         }
+
+        if (!compositeModel.getModelChildren().isEmpty()) {
+            switchyardModel.setComposite(compositeModel);
+        }
+
         return new ScannerOutput<SwitchYardModel>().setModel(switchyardModel);
     }
 

--- a/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
+++ b/rules/src/test/java/org/switchyard/component/rules/config/model/RulesModelTests.java
@@ -126,4 +126,13 @@ public class RulesModelTests {
         }
     }
 
+    @Test
+    public void testEmptyScan() throws Exception {
+        Scanner<SwitchYardModel> scanner = new RulesSwitchYardScanner();
+        ScannerInput<SwitchYardModel> input = new ScannerInput<SwitchYardModel>();
+        ScannerOutput<SwitchYardModel> output = scanner.scan(input);
+        Assert.assertNull("Composite element should not be created if no components were found.", output.getModel()
+                .getComposite());
+    }
+
 }


### PR DESCRIPTION
scanners now only add a composite element if a component was found and added.

there was also a problem with one of the camel tests that was trying to scan a subdirectory.  an enhancement was made to ClasspathScanner (in core) to get the test working properly (it wasn't running at all previously as no components were scanned).
