### PR TITLE
SWITCHYARD-552 remove import schemaLocation from bpel-v1.xsd

### DIFF
--- a/bpel/src/main/resources/org/switchyard/component/bpel/config/model/v1/bpel-v1.xsd
+++ b/bpel/src/main/resources/org/switchyard/component/bpel/config/model/v1/bpel-v1.xsd
@@ -9,8 +9,7 @@ Copyright (c) OASIS Open 2008. All Rights Reserved.
 		elementFormDefault="qualified">
 
 	<!-- SCA-Assembly XML Schema -->
-    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            schemaLocation="sca-1.1-cd06.xsd"/>
+    <import namespace="http://docs.oasis-open.org/ns/opencsa/sca/200912"/>
 
 	<!-- SCA-BPEL Component Implementation Type -->
 	<element name="implementation.bpel"


### PR DESCRIPTION
allows XML validation in Eclipse without errors
