### PR TITLE
SWITCHYARD-651: maven shade plugin missing BPM task.work classes

### DIFF
--- a/tools/forge/bpm/pom.xml
+++ b/tools/forge/bpm/pom.xml
@@ -42,7 +42,7 @@
                     <include>org/switchyard/config/**</include>
                     <include>org/switchyard/component/bpm/*</include>
                     <include>org/switchyard/component/bpm/config/model/**</include>
-                    <include>org/switchyard/component/bpm/task/*</include>
+                    <include>org/switchyard/component/bpm/task/work/*</include>
                   </includes>
                 </filter>
               </filters>


### PR DESCRIPTION
SWITCHYARD-651: maven shade plugin missing BPM task.work classes
https://issues.jboss.org/browse/SWITCHYARD-651
