### PR TITLE
SWITCHYARD-592: Generated BPM definition should contain variable definitions for in and out message

### DIFF
--- a/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
+++ b/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
@@ -76,6 +76,8 @@ public class BPMServicePlugin implements Plugin {
     private static final String PROCESS_DIR = "META-INF";
     // VAR_* constants reference substitution tokens in the process definition template 
     private static final String VAR_PROCESS_ID   = "${process.id}";
+    private static final String VAR_MESSAGE_CONTENT_IN_NAME = "${message.content.in.name}";
+    private static final String VAR_MESSAGE_CONTENT_OUT_NAME = "${message.content.out.name}";
     
     @Inject
     private Project _project;
@@ -115,12 +117,12 @@ public class BPMServicePlugin implements Plugin {
             final String argProcessId,
             @Option(required = false,
                     name = MESSAGE_CONTENT_IN_NAME,
-                    description="The process variable name for the content of the incoming message",
+                    description="The process variable name for the content of the incoming message (" + MESSAGE_CONTENT_IN + ")",
                     defaultValue = MESSAGE_CONTENT_IN)
             final String argMessageContentInName,
             @Option(required = false,
                     name = MESSAGE_CONTENT_OUT_NAME,
-                    description="The process variable name for the content of the outgoing message",
+                    description="The process variable name for the content of the outgoing message (" + MESSAGE_CONTENT_OUT + ")",
                     defaultValue = MESSAGE_CONTENT_OUT)
             final String argMessageContentOutName,
             @Option(required = false,
@@ -170,6 +172,8 @@ public class BPMServicePlugin implements Plugin {
             TemplateResource template = new TemplateResource(PROCESS_TEMPLATE)
                 .serviceName(argServiceName)
                 .replaceToken(VAR_PROCESS_ID, processId)
+                .replaceToken(VAR_MESSAGE_CONTENT_IN_NAME, argMessageContentInName)
+                .replaceToken(VAR_MESSAGE_CONTENT_OUT_NAME, argMessageContentOutName)
                 .packageName(pkgName);
             template.writeResource(_project.getFacet(ResourceFacet.class).getResource(processDefinitionPath));
             

--- a/tools/forge/bpm/src/main/resources/ProcessTemplate.bpmn
+++ b/tools/forge/bpm/src/main/resources/ProcessTemplate.bpmn
@@ -12,6 +12,39 @@
              xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
              xmlns:tns="http://www.jboss.org/drools">
 
+  <itemDefinition id="_messageContentInItem" />
+  <itemDefinition id="_messageContentOutItem" />
+
   <process processType="Private" isExecutable="true" id="${process.id}" name="${service.name}" tns:packageName="${package.name}"/>
+
+    <!-- process variables -->
+    <property id="${message.content.in.name}" itemSubjectRef="_messageContentInItem"/>
+    <property id="${message.content.out.name}" itemSubjectRef="_messageContentOutItem"/>
+
+    <!-- nodes -->
+    <startEvent id="_1" name="StartProcess" />
+    <endEvent id="_2" name="End" >
+        <terminateEventDefinition/>
+    </endEvent>
+
+    <!-- connections -->
+    <sequenceFlow id="_1-_2" sourceRef="_1" targetRef="_2" />
+
+  </process>
+
+  <bpmndi:BPMNDiagram>
+    <bpmndi:BPMNPlane bpmnElement="com.sample.bpmn" >
+      <bpmndi:BPMNShape bpmnElement="_1" >
+        <dc:Bounds x="45" y="45" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="_2" >
+        <dc:Bounds x="145" y="45" width="48" height="48" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="_1-_2" >
+        <di:waypoint x="69" y="69" />
+        <di:waypoint x="138" y="69" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
 
 </definitions>


### PR DESCRIPTION
SWITCHYARD-592: Generated BPM definition should contain variable definitions for in and out message
https://issues.jboss.org/browse/SWITCHYARD-592
