### PR TITLE
SWITCHYARD-695 Forge soap binding commands do not add interface.wsdl

### DIFF
--- a/soap/src/main/java/org/switchyard/component/soap/config/model/SOAPBindingModel.java
+++ b/soap/src/main/java/org/switchyard/component/soap/config/model/SOAPBindingModel.java
@@ -104,7 +104,15 @@ public class SOAPBindingModel extends V1BindingModel {
      * @param port the port to set
      */
     public void setPort(PortName port) {
-        this._port = port;
+        _port = port;
+        Configuration childConfig = getModelConfiguration().getFirstChild(PORT);
+        if (childConfig == null) {
+            ValueModel portConfig = new ValueModel(PORT);
+            portConfig.setValue(port.getName());
+            setChildModel(portConfig);
+        } else {
+            childConfig.setValue(port.getName());
+        }
     }
 
     /**
@@ -128,7 +136,7 @@ public class SOAPBindingModel extends V1BindingModel {
      * @param wsdl the wsdl to set
      */
     public void setWsdl(String wsdl) {
-        this._wsdl = wsdl;
+        _wsdl = wsdl;
         Configuration childConfig = getModelConfiguration().getFirstChild(WSDL);
         if (childConfig == null) {
             ValueModel portConfig = new ValueModel(WSDL);
@@ -157,7 +165,7 @@ public class SOAPBindingModel extends V1BindingModel {
      * @param serviceName the serviceName to set
      */
     public void setServiceName(QName serviceName) {
-        this._serviceName = serviceName;
+        _serviceName = serviceName;
     }
 
     /**
@@ -192,7 +200,15 @@ public class SOAPBindingModel extends V1BindingModel {
      * @param socketAddr the IP Socket Address to set
      */
     public void setSocketAddr(SocketAddr socketAddr) {
-        this._socketAddr = socketAddr;
+        _socketAddr = socketAddr;
+        Configuration childConfig = getModelConfiguration().getFirstChild(SOCKET_ADDRESS);
+        if (childConfig == null) {
+            ValueModel addrConfig = new ValueModel(SOCKET_ADDRESS);
+            addrConfig.setValue(socketAddr.toString());
+            setChildModel(addrConfig);
+        } else {
+            childConfig.setValue(socketAddr.toString());
+        }
     }
 
     /**

--- a/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPBindingPlugin.java
+++ b/tools/forge/soap/src/main/java/org/switchyard/tools/forge/soap/SOAPBindingPlugin.java
@@ -37,6 +37,8 @@ import org.switchyard.component.soap.PortName;
 import org.switchyard.component.soap.config.model.SOAPBindingModel;
 import org.switchyard.config.model.composite.CompositeReferenceModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
+import org.switchyard.config.model.composite.InterfaceModel;
+import org.switchyard.config.model.composite.v1.V1InterfaceModel;
 import org.switchyard.tools.forge.plugin.SwitchYardFacet;
 
 /**
@@ -57,6 +59,7 @@ public class SOAPBindingPlugin implements Plugin {
      * @param serviceName name of the reference to bind
      * @param wsdlLocation location of the WSDL to configure the SOAP binding
      * @param socketAddr optional value for the ip+port
+     * @param portType optional value for interface portType
      * @param out shell output
      */
     @Command(value = "bind-service", help = "Add a SOAP binding to a service.")
@@ -73,6 +76,10 @@ public class SOAPBindingPlugin implements Plugin {
                     name = "socketAddr",
                     description = "Bind to this ip+port for SOAP endpoints") 
             final String socketAddr,
+            @Option(required = false,
+                    name = "portType",
+                    description = "portType to use for interface definition") 
+            final String portType,
             final PipeOut out) {
         
         SwitchYardFacet switchYard = _project.getFacet(SwitchYardFacet.class);
@@ -81,6 +88,12 @@ public class SOAPBindingPlugin implements Plugin {
         if (service == null) {
             out.println(out.renderColor(ShellColor.RED, "No public service named: " + serviceName));
             return;
+        }
+        
+        if (portType != null) {
+            InterfaceModel intf = new V1InterfaceModel(InterfaceModel.WSDL);
+            intf.setInterface(wsdlLocation + "#wsdl.porttype(" + portType + ")");
+            service.setInterface(intf);
         }
         
         SOAPBindingModel binding = new SOAPBindingModel();
@@ -100,6 +113,7 @@ public class SOAPBindingPlugin implements Plugin {
      * @param referenceName name of the reference to bind
      * @param wsdlLocation location of the WSDL to configure the SOAP binding
      * @param portName optional value for the endpoint port
+     * @param portType optional value for interface portType
      * @param out shell output
      */
     @Command(value = "bind-reference", help = "Add a SOAP binding to a reference.")
@@ -116,6 +130,10 @@ public class SOAPBindingPlugin implements Plugin {
                     name = "portName",
                     description = "Port name in WSDL") 
             final String portName,
+            @Option(required = false,
+                    name = "portType",
+                    description = "portType to use for interface definition") 
+            final String portType,
             final PipeOut out) {
         
         SwitchYardFacet switchYard = _project.getFacet(SwitchYardFacet.class);
@@ -124,6 +142,12 @@ public class SOAPBindingPlugin implements Plugin {
         if (reference == null) {
             out.println(out.renderColor(ShellColor.RED, "No public reference named: " + referenceName));
             return;
+        }
+
+        if (portType != null) {
+            InterfaceModel intf = new V1InterfaceModel(InterfaceModel.WSDL);
+            intf.setInterface(wsdlLocation + "#wsdl.porttype(" + portType + ")");
+            reference.setInterface(intf);
         }
         
         SOAPBindingModel binding = new SOAPBindingModel();


### PR DESCRIPTION
We don't have a straightforward way of testing this until Mario's forge test suite support goes in, so I tested this manually, with and without the new portType option.

https://issues.jboss.org/browse/SWITCHYARD-695
