### PR TITLE
SWITCHYARD-717: Objects need to be re-set into TaskContent for serialization

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/task/service/BaseTaskContent.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/task/service/BaseTaskContent.java
@@ -34,9 +34,11 @@ import org.switchyard.exception.SwitchYardException;
  *
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
-public abstract class BaseTaskContent implements TaskContent {
+public class BaseTaskContent implements TaskContent {
 
     private Long _id;
+    private String _type;
+    private Object _object;
 
     /**
      * {@inheritDoc}
@@ -59,9 +61,98 @@ public abstract class BaseTaskContent implements TaskContent {
      * {@inheritDoc}
      */
     @Override
+    public String getType() {
+        return _type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskContent setType(String type) {
+        _type = type;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public Object getObject() {
+        return _object;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T getObject(Class<T> clazz) {
+        return clazz.cast(getObject());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskContent setObject(Object object) {
+        _object = object;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getMap() {
+        return (Map<String, Object>)getObject(Map.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskContent setMap(Map<String, Object> map) {
+        setObject(map);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] getBytes() {
+        byte[] bytes = null;
+        final Object object = getObject();
+        if (object != null) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = null;
+            try {
+                oos = new ObjectOutputStream(baos);
+                oos.writeObject(object);
+                oos.flush();
+            } catch (IOException ioe) {
+                throw new SwitchYardException(ioe);
+            } finally {
+                if (oos != null) {
+                    try {
+                        oos.close();
+                    } catch (IOException ioe) {
+                        throw new SwitchYardException(ioe);
+                    }
+                }
+            }
+            bytes = baos.toByteArray();
+        }
+        return bytes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TaskContent setBytes(byte[] bytes) {
         Object object = null;
-        byte[] bytes = getBytes();
         if (bytes != null && bytes.length > 0) {
             ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
             ObjectInputStream ois = null;
@@ -88,62 +179,7 @@ public abstract class BaseTaskContent implements TaskContent {
                 }
             }
         }
-        return object;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public <T> T getObject(Class<T> clazz) {
-        return clazz.cast(getObject());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TaskContent setObject(Object object) {
-        byte[] bytes = null;
-        if (object != null) {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ObjectOutputStream oos = null;
-            try {
-                oos = new ObjectOutputStream(baos);
-                oos.writeObject(object);
-                oos.flush();
-            } catch (IOException ioe) {
-                throw new SwitchYardException(ioe);
-            } finally {
-                if (oos != null) {
-                    try {
-                        oos.close();
-                    } catch (IOException ioe) {
-                        throw new SwitchYardException(ioe);
-                    }
-                }
-            }
-            bytes = baos.toByteArray();
-        }
-        setBytes(bytes);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @SuppressWarnings("unchecked")
-    public Map<String, Object> getMap() {
-        return (Map<String, Object>)getObject(Map.class);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public TaskContent setMap(Map<String, Object> map) {
-        setObject(map);
+        setObject(object);
         return this;
     }
 

--- a/bpm/src/main/java/org/switchyard/component/bpm/task/service/TaskContent.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/task/service/TaskContent.java
@@ -55,19 +55,6 @@ public interface TaskContent extends Serializable {
     public TaskContent setType(String type);
 
     /**
-     * Gets the bytes.
-     * @return the bytes
-     */
-    public byte[] getBytes();
-
-    /**
-     * Sets the bytes.
-     * @param bytes the bytes
-     * @return this Content (useful for chaining)
-     */
-    public TaskContent setBytes(byte[] bytes);
-
-    /**
      * Gets the object.
      * @return the object
      */
@@ -88,7 +75,6 @@ public interface TaskContent extends Serializable {
      */
     public TaskContent setObject(Object object);
 
-
     /**
      * Gets the map.
      * @return the map
@@ -101,5 +87,18 @@ public interface TaskContent extends Serializable {
      * @return this Content (useful for chaining)
      */
     public TaskContent setMap(Map<String, Object> map);
+
+    /**
+     * Gets the bytes.
+     * @return the bytes
+     */
+    public byte[] getBytes();
+
+    /**
+     * Sets the bytes.
+     * @param bytes the bytes
+     * @return this Content (useful for chaining)
+     */
+    public TaskContent setBytes(byte[] bytes);
 
 }

--- a/bpm/src/main/java/org/switchyard/component/bpm/task/service/jbpm/JBPMTaskContent.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/task/service/jbpm/JBPMTaskContent.java
@@ -19,8 +19,9 @@
 package org.switchyard.component.bpm.task.service.jbpm;
 
 import org.jbpm.task.AccessType;
+import org.jbpm.task.Content;
+import org.jbpm.task.service.ContentData;
 import org.switchyard.component.bpm.task.service.BaseTaskContent;
-import org.switchyard.component.bpm.task.service.TaskContent;
 
 /**
  * A jBPM TaskContent implementation.
@@ -29,67 +30,43 @@ import org.switchyard.component.bpm.task.service.TaskContent;
  */
 public class JBPMTaskContent extends BaseTaskContent {
 
-    private final org.jbpm.task.service.ContentData _wrapped;
-
-    /**
-     * Creates a new JBPMTaskContent with the specified ContentData.
-     * @param contentData the specified ContentData.
-     */
-    public JBPMTaskContent(org.jbpm.task.service.ContentData contentData) {
-        if (contentData != null) {
-            _wrapped = contentData;
-        } else {
-            _wrapped = new org.jbpm.task.service.ContentData();
-            _wrapped.setAccessType(AccessType.Inline);
-        }
-    }
+    private AccessType _accessType;
 
     /**
      * Creates a new JBPMTaskContent with the specified Content.
      * @param content the specified Content
      */
-    public JBPMTaskContent(org.jbpm.task.Content content) {
-        this((org.jbpm.task.service.ContentData)null);
-        _wrapped.setContent(content.getContent());
+    public JBPMTaskContent(Content content) {
         setId(content.getId());
-    }
-
-    org.jbpm.task.service.ContentData getWrapped() {
-        return _wrapped;
-    }
-
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getType() {
-        return _wrapped.getType();
+        setAccessType(AccessType.Inline);
+        setBytes(content.getContent());
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a new JBPMTaskContent with the specified ContentData.
+     * @param contentData the specified ContentData.
      */
-    @Override
-    public TaskContent setType(String type) {
-        _wrapped.setType(type);
-        return this;
+    public JBPMTaskContent(ContentData contentData) {
+        setType(contentData.getType());
+        setAccessType(contentData.getAccessType());
+        setBytes(contentData.getContent());
     }
 
     /**
-     * {@inheritDoc}
+     * Gets the access type.
+     * @return the access type
      */
-    @Override
-    public byte[] getBytes() {
-        return _wrapped.getContent();
+    public AccessType getAccessType() {
+        return _accessType;
     }
 
     /**
-     * {@inheritDoc}
+     * Sets the access type.
+     * @param accessType the access type
+     * @return this instance (useful for chaining)
      */
-    @Override
-    public TaskContent setBytes(byte[] bytes) {
-        _wrapped.setContent(bytes);
+    public JBPMTaskContent setAccessType(AccessType accessType) {
+        _accessType = accessType;
         return this;
     }
 


### PR DESCRIPTION
SWITCHYARD-717: Objects need to be re-set into TaskContent for serialization
https://issues.jboss.org/browse/SWITCHYARD-717
