### PR TITLE
SWITCHYARD-913 JCA component fails to be built with empty M2 repo

### DIFF
--- a/jca/pom.xml
+++ b/jca/pom.xml
@@ -84,10 +84,6 @@
             <artifactId>jboss-as-connector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-ra</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
             <artifactId>ironjacamar-core-api</artifactId>
         </dependency>


### PR DESCRIPTION
Fixed broken dependencies on HornetQ which is used by JCAMixIn
