### PR TITLE
SWITCHYARD-969 JCA JMS outbound does not work with certain configs

### DIFF
--- a/jca/src/main/java/org/switchyard/component/jca/processor/JMSProcessor.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/JMSProcessor.java
@@ -77,13 +77,10 @@ public class JMSProcessor extends AbstractOutboundProcessor {
 
     @Override
     public void initialize() {
-        if (_transacted == null || _transacted.equals("")) {
-            _txEnabled = true;
-        } else {
-            _txEnabled = Boolean.parseBoolean(_transacted);
-        }
+        _txEnabled = Boolean.parseBoolean(_transacted);
+
         if (_acknowledgeMode == null || _acknowledgeMode.equals("")) {
-            _ackMode = Session.SESSION_TRANSACTED;
+            _ackMode = Session.AUTO_ACKNOWLEDGE;
         } else {
             _ackMode = Integer.parseInt(_acknowledgeMode);
         }


### PR DESCRIPTION
JMSProcessor enables JMS local transaction by default, but doesn't commit it. It still works if JTA transaction is handled from outside of JCA outbound, but if not, JMS session will be closed without commit causes rollback. We need to disable JMS local transaction by default to avoid user confusion.
