### PR TITLE
SWITCHYARD-1054: BPM process/signal event data can only be from context, not content

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/exchange/BaseBPMExchangeHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/exchange/BaseBPMExchangeHandler.java
@@ -147,22 +147,21 @@ public abstract class BaseBPMExchangeHandler extends BaseHandler implements BPME
     }
 
     /**
-     * Gets the process event from the Exchange Context.
+     * Gets the process event from the Exchange Context, or if null, the Message content.
      * @param context the Exchange Context
      * @param message the Message
      * @return the process event
      */
     protected Object getProcessEvent(Context context, Message message) {
+        Object pe = null;
         Property property = context.getProperty(PROCESS_EVENT_VAR, EXCHANGE);
         if (property != null) {
-            Object value = property.getValue();
-            if (value != null) {
-                return value;
-            } else if (message != null) {
-                return message.getContent();
-            }
+            pe = property.getValue();
         }
-        return null;
+        if (pe == null && message != null) {
+            pe = message.getContent();
+        }
+        return pe;
     }
 
     /**

--- a/tools/forge/http/src/main/java/org/switchyard/tools/forge/http/HttpBindingPlugin.java
+++ b/tools/forge/http/src/main/java/org/switchyard/tools/forge/http/HttpBindingPlugin.java
@@ -19,8 +19,6 @@
 
 package org.switchyard.tools.forge.http;
 
-import java.lang.reflect.Method;
-
 import javax.inject.Inject;
 
 import org.jboss.forge.project.Project;
@@ -37,7 +35,6 @@ import org.jboss.forge.shell.plugins.RequiresProject;
 import org.jboss.forge.shell.plugins.Topic;
 import org.switchyard.component.common.selector.config.model.v1.V1StaticOperationSelectorModel;
 import org.switchyard.component.http.config.model.HttpBindingModel;
-import org.switchyard.config.model.Model;
 import org.switchyard.config.model.composite.CompositeReferenceModel;
 import org.switchyard.config.model.composite.CompositeServiceModel;
 import org.switchyard.tools.forge.plugin.SwitchYardFacet;


### PR DESCRIPTION
SWITCHYARD-1054: BPM process/signal event data can only be from context, not content
https://issues.jboss.org/browse/SWITCHYARD-1054
