### PR TITLE
SWITCHYARD-1010 Handle Implementation Policy and Reference Interaction P...

### DIFF
--- a/bean/src/test/java/org/switchyard/component/bean/tests/LocalTransactionBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/LocalTransactionBean.java
@@ -30,7 +30,7 @@ import org.switchyard.policy.TransactionPolicy;
 @Service(value = OneWay.class, name = "LocalTransactionService")
 public class LocalTransactionBean implements OneWay {
     
-    @Inject @Reference
+    @Inject @Reference @Requires(transaction = TransactionPolicy.SUSPENDS_TRANSACTION)
     private OneWay oneWay;
 
 	@Override

--- a/bean/src/test/java/org/switchyard/component/bean/tests/SecureBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/SecureBean.java
@@ -30,7 +30,7 @@ import org.switchyard.policy.SecurityPolicy;
 @Service(value = OneWay.class, name = "SecureService")
 public class SecureBean implements OneWay {
     
-    @Inject @Reference
+    @Inject @Reference @Requires(security = {SecurityPolicy.CLIENT_AUTHENTICATION, SecurityPolicy.CONFIDENTIALITY})
     private OneWay oneWay;
 
 	@Override

--- a/bean/src/test/java/org/switchyard/component/bean/tests/SharedTransactionBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/SharedTransactionBean.java
@@ -30,7 +30,7 @@ import org.switchyard.policy.TransactionPolicy;
 @Service(value = OneWay.class, name = "SharedTransactionService")
 public class SharedTransactionBean implements OneWay {
     
-    @Inject @Reference
+    @Inject @Reference @Requires(transaction = TransactionPolicy.PROPAGATES_TRANSACTION)
     private OneWay oneWay;
 
 	@Override

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/InboundHandler.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/InboundHandler.java
@@ -138,7 +138,7 @@ public class InboundHandler extends BaseServiceHandler {
 
     private void addToCamelRegistry(final OperationSelector<CamelBindingData> selector) {
         final SimpleRegistry simpleRegistry = new SimpleRegistry();
-        simpleRegistry.put(_serviceName.getLocalPart() + OPERATION_SELECTOR_REF, selector);
+        simpleRegistry.put(_serviceName.toString() + OPERATION_SELECTOR_REF, selector);
         final PropertyPlaceholderDelegateRegistry delegateReg = (PropertyPlaceholderDelegateRegistry) _camelContext.getRegistry();
         final CompositeRegistry registry = (CompositeRegistry) delegateReg.getRegistry();
         registry.addRegistry(simpleRegistry);
@@ -166,11 +166,11 @@ public class InboundHandler extends BaseServiceHandler {
     }
 
     private String composeSwitchYardComponentName(final QName serviceName) {
-        return new StringBuilder()
-                    .append("switchyard://")
-                    .append(serviceName.getLocalPart())
-                    .toString();
-
+        final StringBuilder sb = new StringBuilder()
+                                        .append("switchyard://")
+                                        .append(serviceName.getLocalPart());
+        final String namespace = Strings.trimToNull(serviceName.getNamespaceURI());
+        return SwitchYardRouteDefinition.addNamespaceParameter(sb.toString(), namespace);
     }
 
     /**

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -81,15 +81,14 @@ public class SwitchYardProducer extends DefaultProducer {
         ServiceDomain domain = (ServiceDomain)camelExchange.getContext().getRegistry().lookup(CamelActivator.SERVICE_DOMAIN);
         
         final ServiceReference serviceRef = lookupServiceReference(targetUri, domain);
-        final String serviceName = serviceRef.getName().getLocalPart();
+        final QName serviceName = serviceRef.getName();
         @SuppressWarnings("unchecked")
         OperationSelector<CamelBindingData> selector =
                 (OperationSelector<CamelBindingData>) camelExchange.getContext()
                                                                     .getRegistry()
-                                                                    .lookup(serviceName + InboundHandler.OPERATION_SELECTOR_REF);
+                                                                    .lookup(serviceName.toString() + InboundHandler.OPERATION_SELECTOR_REF);
         if (selector != null) {
             QName op = selector.selectOperation(new CamelBindingData(camelExchange.getIn()));
-            _namespace = op.getNamespaceURI();
             _operationName = op.getLocalPart();
         }
         
@@ -98,6 +97,7 @@ public class SwitchYardProducer extends DefaultProducer {
         // Set appropriate policy based on Camel exchange properties
         if (camelExchange.isTransacted()) {
             PolicyUtil.provide(switchyardExchange, TransactionPolicy.PROPAGATES_TRANSACTION);
+            PolicyUtil.provide(switchyardExchange, TransactionPolicy.MANAGED_TRANSACTION_GLOBAL);
         }
         
         Message switchyardMessage = _messageComposer.compose(new CamelBindingData(camelExchange.getIn()), switchyardExchange, true);

--- a/jca/src/main/java/org/switchyard/component/jca/composer/JMSContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/JMSContextMapper.java
@@ -76,9 +76,9 @@ public class JMSContextMapper extends BaseRegexContextMapper<JMSBindingData> {
                     try {
                         // Context EXCHANGE properties -> JMS Message properties
                         message.setObjectProperty(name, value);
-                    } catch (JMSException pce) {
+                    } catch (Throwable t) {
                         // ignore and keep going (here just to keep checkstyle happy)
-                        pce.getMessage();
+                        t.getMessage();
                     }
                 }
             }

--- a/jca/src/main/java/org/switchyard/component/jca/endpoint/AbstractInflowEndpoint.java
+++ b/jca/src/main/java/org/switchyard/component/jca/endpoint/AbstractInflowEndpoint.java
@@ -200,8 +200,7 @@ public abstract class AbstractInflowEndpoint {
         Exchange exchange = _serviceRef.createExchange(operation, handler);
         if (_transacted) {
             PolicyUtil.provide(exchange, TransactionPolicy.PROPAGATES_TRANSACTION);
-        } else {
-            PolicyUtil.provide(exchange, TransactionPolicy.SUSPENDS_TRANSACTION);
+            PolicyUtil.provide(exchange, TransactionPolicy.MANAGED_TRANSACTION_GLOBAL);
         }
         return exchange;
         


### PR DESCRIPTION
...olicy

including
- BeanSwitchYardScanner: Separately process interaction and implementation policies declared by Requires annotation on service class
- BeanSwitchYardScanner: Add Requires annotation handling on service reference
- fix camel InboundHandler to pass the namespace to the Endpoint by parameter (it was deleted by SWITCHYARD-916, but actually shouldn't)
- https://issues.jboss.org/browse/SWITCHYARD-1037 - Use full QName to identify OperationSelector object in camel registry
- https://issues.jboss.org/browse/SWITCHYARD-997 - Few more task for transaction implementation policy (update the policy-transaction demo to demostrate new transaction implementation policy)
