### PR TITLE
SWITCHYARD-1076 Outbound handler returning fault is processed as a normal response

### DIFF
--- a/http/src/test/java/org/switchyard/component/http/HttpGatewayTest.java
+++ b/http/src/test/java/org/switchyard/component/http/HttpGatewayTest.java
@@ -145,7 +145,7 @@ public class HttpGatewayTest {
         Context ctx = ex.getContext();
         Message requestMsg = ex.createMessage().setContent("magesh");
         ex.send(requestMsg);
-        handler.waitForOKMessage();
+        handler.waitForFaultMessage();
         Assert.assertEquals(404, ctx.getProperty("status", Scope.IN).getValue());
     }
 


### PR DESCRIPTION
Small change in HTTP component tests.
