### PR TITLE
SWITCHYARD-1115: ClassNotFoundException when using bpm audit

### DIFF
--- a/common/rules/pom.xml
+++ b/common/rules/pom.xml
@@ -36,6 +36,10 @@
     <dependencies>
         <!-- external dependencies -->
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
         </dependency>

--- a/common/rules/src/main/java/org/switchyard/component/common/rules/util/drools/Audits.java
+++ b/common/rules/src/main/java/org/switchyard/component/common/rules/util/drools/Audits.java
@@ -18,6 +18,7 @@
  */
 package org.switchyard.component.common.rules.util.drools;
 
+import org.apache.commons.lang.text.StrSubstitutor;
 import org.drools.event.KnowledgeRuntimeEventManager;
 import org.drools.logger.KnowledgeRuntimeLogger;
 import org.drools.logger.KnowledgeRuntimeLoggerFactory;
@@ -45,7 +46,7 @@ public final class Audits {
                 type = AuditType.THREADED_FILE;
             }
             String log = Strings.trimToNull(audit.getLog());
-            String fileName = log != null ? log : "event";
+            String fileName = log != null ? StrSubstitutor.replaceSystemProperties(log) : "event";
             Integer interval = audit.getInterval();
             if (interval == null) {
                 interval = Integer.valueOf(1000);


### PR DESCRIPTION
SWITCHYARD-1115: ClassNotFoundException when using bpm audit
https://issues.jboss.org/browse/SWITCHYARD-1115
