### PR TITLE
SWITCHYARD-1161 Add configuration support for Camel Mail component.

### DIFF
--- a/camel/camel-core/pom.xml
+++ b/camel/camel-core/pom.xml
@@ -184,6 +184,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel</groupId>
+            <artifactId>camel-mail</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
             <artifactId>camel-netty</artifactId>
             <scope>compile</scope>
             <exclusions>

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailBindingModel.java
@@ -1,0 +1,151 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.camel.config.model.mail;
+
+import org.switchyard.component.camel.config.model.CamelBindingModel;
+
+/**
+ * Represents the configuration settings for an mail endpoint in Camel. Depends
+ * on produce/consume part different protocols will be used.
+ */
+public interface CamelMailBindingModel extends CamelBindingModel {
+
+    /**
+     * The host name or IP address to connect to.
+     * 
+     * @return Host name or ip.
+     */
+    String getHost();
+
+    /**
+     * Specify host/ip to use.
+     * 
+     * @param host Host or ip address.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setHost(String host);
+
+    /**
+     * The TCP port number to connect on.
+     * 
+     * @return TCP port number
+     */
+    Integer getPort();
+
+    /**
+     * Specify TCP port number to connect.
+     * 
+     * @param port TCP port to use.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setPort(Integer port);
+
+    /**
+     * The user name on the email server.
+     * 
+     * @return User name/login to connect email server.
+     */
+    String getUsername();
+
+    /**
+     * Specify user name to use.
+     * 
+     * @param username Username to use for logging in on server.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setUsername(String username);
+
+    /**
+     * The password on the email server.
+     * 
+     * @return Password to connect email server.
+     */
+    String getPassword();
+
+    /**
+     * Specify password to use.
+     * 
+     * @param password Password for authentication.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setPassword(String password);
+
+    /**
+     * The connection timeout in milliseconds. Default is 30 seconds (30000 millis).
+     * 
+     * @return Connection timeout.
+     */
+    Integer getConnectionTimeout();
+
+    /**
+     * Specify connection timeout.
+     * 
+     * @param connectionTimeout Connection timeout.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setConnectionTimeout(Integer connectionTimeout);
+
+    /**
+     * Returns the secure flag. In other words if connection should be created
+     * using smtps or smtp protocol scheme.
+     * 
+     * @return True if secure connection should be used.
+     */
+    Boolean isSecure();
+
+    /**
+     * Specify if secure connection should be used.
+     * 
+     * @param secure True if secure connection should be created.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setSecure(Boolean secure);
+
+    /**
+     * Gets consumer binding attached to this mail binding.
+     * 
+     * @return Consumer binding model.
+     */
+    CamelMailConsumerBindingModel getConsumer();
+
+    /**
+     * Specify consumer configuration.
+     * 
+     * @param consumer Consumer configuration.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setConsumer(CamelMailConsumerBindingModel consumer);
+
+    /**
+     * Gets producer binding attached to this mail binding.
+     * 
+     * @return Producer binding model.
+     */
+    CamelMailProducerBindingModel getProducer();
+
+    /**
+     * Specify producer configuration.
+     * 
+     * @param producer Producer configuration.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailBindingModel setProducer(CamelMailProducerBindingModel producer);
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailConsumerBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailConsumerBindingModel.java
@@ -1,0 +1,143 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail;
+
+import org.switchyard.component.camel.config.model.CamelScheduledBatchPollConsumer;
+
+/**
+ * Mail consumer/receiver binding model.
+ */
+public interface CamelMailConsumerBindingModel extends CamelScheduledBatchPollConsumer {
+
+    /**
+     * The folder to poll.
+     * 
+     * @return Folder name.
+     */
+    String getFolderName();
+
+    /**
+     * Specify folder name to poll.
+     * 
+     * @param folderName Folder name to use for polling messages.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setFolderName(String folderName);
+
+    /**
+     * Sets the maximum number of messages to consume during a poll.
+     * 
+     * This can be used to avoid overloading a mail server, if a mailbox folder contains a lot of messages.
+     * Default value of -1 means no fetch size and all messages will be consumed. Setting the value to 0
+     * is a special corner case, where Camel will not consume any messages at all.
+     *
+     * @return Number of messages to read by one connection.
+     */
+    Integer getFetchSize();
+
+    /**
+     * Specify maximum number of messages for one poll.
+     * 
+     * @param fetchSize Number of messages to fetch.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setFetchSize(Integer fetchSize);
+
+    /**
+     * Should camel process only unseen messages (that is, new messages) or all messages.
+     * 
+     * Note that Camel always skips deleted messages. The default option of true will filter to only
+     * unseen messages. This setting is applicable only for IMAP.
+     *  
+     * @return Should camel use SEEN flag for choosing messages to process.
+     */
+    Boolean isUnseen();
+
+    /**
+     * Specify to use SEEN flag with IMAP or not.
+     * 
+     * @param unseen True if camel should process only new (unseen) messages.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setUnseen(Boolean unseen);
+
+    /**
+     * Deletes the messages after they have been processed.
+     * 
+     * @return True if DELETED flag should be set on email after processing.
+     */
+    Boolean isDelete();
+
+    /**
+     * Specify if message should be deleted after processing.
+     * 
+     * @param delete True if camel should mark processed messages as deleted.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setDelete(Boolean delete);
+
+    /**
+     * After processing a mail message, it can be copied to a mail folder with the given name.
+     * 
+     * @return Name of folder to copy message after processing.
+     */
+    String getCopyTo();
+
+    /**
+     * Specify folder name to store copies of processed messages.
+     * 
+     * @param copyTo Folder name for storing copies.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setCopyTo(String copyTo);
+
+    /**
+     * Whether the consumer should disconnect after polling. If enabled this forces Camel to connect on each poll.
+     * 
+     * @return True if connection should be closed/opened for each poll.
+     */
+    Boolean isDisconnect();
+
+    /**
+     * Specify if connection should be closed after every poll.
+     * 
+     * @param disconnect Set to true if connection should be closed after poll.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setDisconnect(Boolean disconnect);
+
+    /**
+     * Get's protocol - pop3[s] or imap[s].
+     * 
+     * @return Protocol to use.
+     */
+    String getProtocol();
+
+    /**
+     * Specify mail server backend type.
+     * 
+     * @param accountType Type of server backend. Supported values are IMAP/POP3.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailConsumerBindingModel setAccountType(String accountType);
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailProducerBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/CamelMailProducerBindingModel.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail;
+
+/**
+ * Mail producer/sender binding model.
+ */
+public interface CamelMailProducerBindingModel {
+
+    /**
+     * Subject of the message being sent.
+     * 
+     * @return Mail subject.
+     */
+    String getSubject();
+
+    /**
+     * Specify mail subject to use.
+     * 
+     * @param subject Mail subject.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setSubject(String subject);
+
+    /**
+     * The FROM email address.
+     * 
+     * @return Sender email address.
+     */
+    String getFrom();
+
+    /**
+     * Specify FROM email address.
+     * 
+     * @param from Sender email.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setFrom(String from);
+
+    /**
+     * The TO recipients (the receivers of the mail). Separate multiple email addresses with a comma.
+     * 
+     * @return Mail recipients.
+     */
+    String getTo();
+
+    /**
+     * Specify mail recipients.
+     * 
+     * @param to Mail recipients.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setTo(String to);
+
+    /**
+     * The CC recipients (the receivers of the mail). Separate multiple email addresses with a comma.
+     * 
+     * @return Mail recipients which should receive copy of sent mail.
+     */
+    String getCC();
+
+    /**
+     * Specify mail recipients.
+     * 
+     * @param cc Copy recipients.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setCC(String cc);
+
+    /**
+     * The BCC recipients (the receivers of the mail). Separate multiple email addresses with a comma.
+     * 
+     * @return Mail recipients which should receive copy of sent mail but stay invisible for others recipients.
+     */
+    String getBCC();
+
+    /**
+     * Specify BCC recipients.
+     * 
+     * @param bcc Hidden mail recipients.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setBCC(String bcc);
+
+    /**
+     * The Reply-To recipients (the receivers of the response mail). Separate multiple email addresses with a comma.
+     * 
+     * @return Reply to flag for mail.
+     */
+    String getReplyTo();
+
+    /**
+     * Specifies the addresses that should receive an answer for sent mail.
+     * 
+     * @param replyTo Reply-to addresses.
+     * @return a reference to this Camel binding model
+     */
+    CamelMailProducerBindingModel setReplyTo(String replyTo);
+
+    /**
+     * Get protocol to use - smpt or smpts.
+     * 
+     * @return Protocol to use.
+     */
+    String getProtocol();
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailBindingModel.java
@@ -1,0 +1,189 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import java.net.URI;
+import java.util.List;
+
+import org.switchyard.component.camel.config.model.QueryString;
+import org.switchyard.component.camel.config.model.mail.CamelMailBindingModel;
+import org.switchyard.component.camel.config.model.mail.CamelMailConsumerBindingModel;
+import org.switchyard.component.camel.config.model.mail.CamelMailProducerBindingModel;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelBindingModel;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.composite.CompositeReferenceModel;
+
+/**
+ * First implementation of mail binding.
+ */
+public class V1CamelMailBindingModel extends V1BaseCamelBindingModel
+    implements CamelMailBindingModel {
+
+    /**
+     * Binding name.
+     */
+    public static final String MAIL = "mail";
+
+    private static final String HOST = "host";
+    private static final String PORT = "port";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String CONNECTION_TIMEOUT = "connectionTimeout";
+    private static final String SECURE = "secure";
+
+    /**
+     * Mail consumer binding.
+     */
+    private V1CamelMailConsumerBindingModel _consume;
+
+    /**
+     * Mail producer binding.
+     */
+    private V1CamelMailProducerBindingModel _produce;
+
+    /**
+     * Creates new mail binding model.
+     * 
+     * @param config The switchyard configuration instance.
+     * @param desc The switchyard descriptor instance.
+     */
+    public V1CamelMailBindingModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    /**
+     * Creates new mail binding model.
+     */
+    public V1CamelMailBindingModel() {
+        super(MAIL);
+
+        setModelChildrenOrder(HOST, PORT, USERNAME, PASSWORD, CONNECTION_TIMEOUT,
+            CONSUME, PRODUCE);
+    }
+
+    @Override
+    public String getHost() {
+        return getConfig(HOST);
+    }
+
+    @Override
+    public V1CamelMailBindingModel setHost(String host) {
+        return setConfig(HOST, host);
+    }
+
+    @Override
+    public Integer getPort() {
+        return getIntegerConfig(PORT);
+    }
+
+    @Override
+    public V1CamelMailBindingModel setPort(Integer port) {
+        return setConfig(PORT, port);
+    }
+
+    @Override
+    public String getUsername() {
+        return getConfig(USERNAME);
+    }
+
+    @Override
+    public V1CamelMailBindingModel setUsername(String username) {
+        return setConfig(USERNAME, username);
+    }
+
+    @Override
+    public String getPassword() {
+        return getConfig(PASSWORD);
+    }
+
+    @Override
+    public V1CamelMailBindingModel setPassword(String password) {
+        return setConfig(PASSWORD, password);
+    }
+
+    @Override
+    public Integer getConnectionTimeout() {
+        return getIntegerConfig(CONNECTION_TIMEOUT);
+    }
+
+    @Override
+    public V1CamelMailBindingModel setConnectionTimeout(Integer connectionTimeout) {
+        return setConfig(CONNECTION_TIMEOUT, connectionTimeout);
+    }
+
+    @Override
+    public Boolean isSecure() {
+        return Boolean.valueOf(getModelAttribute(SECURE));
+    }
+
+    @Override
+    public V1CamelMailBindingModel setSecure(Boolean secure) {
+        setModelAttribute(SECURE, Boolean.toString(secure));
+        return this;
+    }
+
+    @Override
+    public V1CamelMailBindingModel setConsumer(CamelMailConsumerBindingModel consumer) {
+        _consume = replaceChildren(CONSUME, (V1CamelMailConsumerBindingModel) consumer);
+        return this;
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel getConsumer() {
+        if (_consume == null) {
+            _consume = new V1CamelMailConsumerBindingModel(getFirstChild(CONSUME), getModelDescriptor());
+        }
+        return _consume;
+    }
+
+    @Override
+    public V1CamelMailBindingModel setProducer(CamelMailProducerBindingModel producer) {
+        _produce = replaceChildren(PRODUCE, (V1CamelMailProducerBindingModel) producer);
+        return this;
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel getProducer() {
+        if (_produce == null) {
+            _produce = new V1CamelMailProducerBindingModel(getFirstChild(PRODUCE), getModelDescriptor());
+        }
+        return _produce;
+    }
+
+    @Override
+    public URI getComponentURI() {
+        Configuration modelConfiguration = getModelConfiguration();
+        List<Configuration> children = modelConfiguration.getChildren();
+
+        QueryString queryString = new QueryString();
+        traverseConfiguration(children, queryString, HOST, PORT);
+
+        boolean producer = getModelParent() instanceof CompositeReferenceModel;
+
+        String protocol = producer ?  getProducer().getProtocol() :getConsumer().getProtocol();
+        String port = getPort() != null ? ":" + getPort() : "";
+
+        return URI.create(protocol + (isSecure() ? "s" : "")  + "://" + getHost() + port + queryString);
+    }
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailConsumerBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailConsumerBindingModel.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.component.camel.config.model.mail.CamelMailConsumerBindingModel;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelBindingModel;
+import org.switchyard.component.camel.config.model.v1.V1CamelScheduledBatchPollConsumer;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+
+/**
+ * First implementation of mail consumer/receiver binding.
+ */
+public class V1CamelMailConsumerBindingModel extends V1CamelScheduledBatchPollConsumer
+    implements CamelMailConsumerBindingModel {
+
+    /**
+     * Enumeration type representing supported mail server types.
+     */
+    public enum AccountType {
+        /**
+         * Imap based backend.
+         */
+        imap,
+        /**
+         * POP3 based backend.
+         */
+        pop3;
+    }
+
+    private static final String ACCOUNT_TYPE = "accountType";
+    private static final String FOLDER_NAME = "folderName";
+    private static final String FETCH_SIZE = "fetchSize";
+    private static final String UNSEEN = "unseen";
+    private static final String DELETE = "delete";
+    private static final String COPY_TO = "copyTo";
+    private static final String DISCONNECT = "disconnect";
+
+    /**
+     * Creates new consumer binding model.
+     */
+    public V1CamelMailConsumerBindingModel() {
+        super(new QName(V1BaseCamelBindingModel.CONSUME));
+
+        setModelChildrenOrder(FOLDER_NAME, FETCH_SIZE, UNSEEN, DELETE, COPY_TO, DISCONNECT);
+    }
+
+    /**
+     * Creates new consumer binding model.
+     * 
+     * @param config The switchyard configuration instance.
+     * @param desc The switchyard descriptor instance.
+     */
+    public V1CamelMailConsumerBindingModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    @Override
+    public String getFolderName() {
+        return getConfig(FOLDER_NAME);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setFolderName(String folderName) {
+        return setConfig(FOLDER_NAME, folderName);
+    }
+
+    @Override
+    public Integer getFetchSize() {
+        return getIntegerConfig(FETCH_SIZE);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setFetchSize(Integer fetchSize) {
+        return setConfig(FETCH_SIZE, fetchSize);
+    }
+
+    @Override
+    public Boolean isUnseen() {
+        return getBooleanConfig(UNSEEN);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setUnseen(Boolean unseen) {
+        return setConfig(UNSEEN, unseen);
+    }
+
+    @Override
+    public Boolean isDelete() {
+        return getBooleanConfig(DELETE);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setDelete(Boolean delete) {
+        return setConfig(DELETE, delete);
+    }
+
+    @Override
+    public String getCopyTo() {
+        return getConfig(COPY_TO);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setCopyTo(String copyTo) {
+        return setConfig(COPY_TO, copyTo);
+    }
+
+    @Override
+    public Boolean isDisconnect() {
+        return getBooleanConfig(DISCONNECT);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setDisconnect(Boolean disconnect) {
+        return setConfig(DISCONNECT, disconnect);
+    }
+
+    @Override
+    public V1CamelMailConsumerBindingModel setAccountType(String accountType) {
+        setModelAttribute(ACCOUNT_TYPE, accountType);
+        return this;
+    }
+
+    @Override
+    public String getProtocol() {
+        String modelAttribute = getModelAttribute(ACCOUNT_TYPE);
+        AccountType accountType = modelAttribute != null ? AccountType.valueOf(modelAttribute) : AccountType.imap;
+        return accountType.name();
+    }
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailProducerBindingModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailProducerBindingModel.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import javax.xml.namespace.QName;
+
+import org.switchyard.component.camel.config.model.mail.CamelMailProducerBindingModel;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelModel;
+import org.switchyard.component.camel.config.model.v1.V1CamelBindingModel;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+
+/**
+ * First implementation of mail producer binding.
+ */
+public class V1CamelMailProducerBindingModel extends V1BaseCamelModel 
+    implements CamelMailProducerBindingModel {
+
+    /**
+     * Camel endpoint type used for mail producers.
+     */
+    private static final String SMTP = "smtp";
+
+    private static final String SUBJECT = "subject";
+    private static final String FROM = "from";
+    private static final String TO = "to";
+    private static final String CC = "CC";
+    private static final String BCC = "BCC";
+    private static final String REPLY_TO = "replyTo";
+
+    /**
+     * Creates new producer binding model.
+     */
+    public V1CamelMailProducerBindingModel() {
+        super(new QName(V1CamelBindingModel.PRODUCE));
+
+        setModelChildrenOrder(SUBJECT, FROM, TO, CC, BCC, REPLY_TO);
+    }
+
+    /**
+     * Creates new producer binding model.
+     * 
+     * @param config The switchyard configuration instance.
+     * @param desc The switchyard descriptor instance.
+     */
+    public V1CamelMailProducerBindingModel(Configuration config, Descriptor desc) {
+        super(config, desc);
+    }
+
+    @Override
+    public String getSubject() {
+        return getConfig(SUBJECT);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setSubject(String subject) {
+        return setConfig(SUBJECT, subject);
+    }
+
+    @Override
+    public String getFrom() {
+        return getConfig(FROM);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setFrom(String from) {
+        return setConfig(FROM, from);
+    }
+
+    @Override
+    public String getTo() {
+        return getConfig(TO);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setTo(String to) {
+        return setConfig(TO, to);
+    }
+
+    @Override
+    public String getCC() {
+        return getConfig(CC);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setCC(String cc) {
+        return setConfig(CC, cc);
+    }
+
+    @Override
+    public String getBCC() {
+        return getConfig(BCC);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setBCC(String bcc) {
+        return setConfig(BCC, bcc);
+    }
+
+    @Override
+    public String getReplyTo() {
+        return getConfig(REPLY_TO);
+    }
+
+    @Override
+    public V1CamelMailProducerBindingModel setReplyTo(String replyTo) {
+        return setConfig(REPLY_TO, replyTo);
+    }
+
+    @Override
+    public String getProtocol() {
+        return SMTP;
+    }
+
+}

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1BaseCamelModel.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1BaseCamelModel.java
@@ -93,6 +93,7 @@ public abstract class V1BaseCamelModel extends BaseModel {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     protected <X extends V1BaseCamelModel> X setConfig(String name, Object value) {
         String modelValue = String.valueOf(value);
         Configuration config = getModelConfiguration().getFirstChild(name);

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelModelMarshaller.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelModelMarshaller.java
@@ -23,11 +23,10 @@ package org.switchyard.component.camel.config.model.v1;
 import org.switchyard.component.camel.config.model.atom.v1.V1CamelAtomBindingModel;
 import org.switchyard.component.camel.config.model.direct.v1.V1CamelDirectBindingModel;
 import org.switchyard.component.camel.config.model.file.v1.V1CamelFileBindingModel;
-import org.switchyard.component.camel.config.model.file.v1.V1CamelFileConsumerBindingModel;
-import org.switchyard.component.camel.config.model.file.v1.V1CamelFileProducerBindingModel;
 import org.switchyard.component.camel.config.model.ftp.v1.V1CamelFtpBindingModel;
 import org.switchyard.component.camel.config.model.ftps.v1.V1CamelFtpsBindingModel;
 import org.switchyard.component.camel.config.model.jms.v1.V1CamelJmsBindingModel;
+import org.switchyard.component.camel.config.model.mail.v1.V1CamelMailBindingModel;
 import org.switchyard.component.camel.config.model.mock.v1.V1CamelMockBindingModel;
 import org.switchyard.component.camel.config.model.netty.v1.V1CamelNettyTcpBindingModel;
 import org.switchyard.component.camel.config.model.netty.v1.V1CamelNettyUdpBindingModel;
@@ -101,15 +100,9 @@ public class V1CamelModelMarshaller extends BaseMarshaller {
                 return new V1CamelQuartzBindingModel(config, getDescriptor());
             } else if (name.endsWith(V1CamelSqlBindingModel.SQL)) {
                 return new V1CamelSqlBindingModel(config, getDescriptor());
+            } else if (name.endsWith(V1CamelMailBindingModel.MAIL)) {
+                return new V1CamelMailBindingModel(config, getDescriptor());
             }
-        }
-
-        if (name.endsWith(V1CamelFileBindingModel.CONSUME)) {
-            return new V1CamelFileConsumerBindingModel(config, getDescriptor());
-        }
-
-        if (name.endsWith(V1CamelFileBindingModel.PRODUCE)) {
-            return new V1CamelFileProducerBindingModel(config, getDescriptor());
         }
 
         if (name.startsWith(ComponentImplementationModel.IMPLEMENTATION)) {

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelScheduledBatchPollConsumer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelScheduledBatchPollConsumer.java
@@ -44,6 +44,8 @@ public class V1CamelScheduledBatchPollConsumer extends V1CamelScheduledPollConsu
      */
     public V1CamelScheduledBatchPollConsumer(QName qname) {
         super(qname);
+
+        setModelChildrenOrder(MAX_MESSAGES_PER_POLL);
     }
 
     /**
@@ -54,8 +56,6 @@ public class V1CamelScheduledBatchPollConsumer extends V1CamelScheduledPollConsu
      */
     public V1CamelScheduledBatchPollConsumer(Configuration config, Descriptor desc) {
         super(config, desc);
-
-        setModelChildrenOrder(MAX_MESSAGES_PER_POLL);
     }
 
     @Override

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelScheduledPollConsumer.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/config/model/v1/V1CamelScheduledPollConsumer.java
@@ -64,6 +64,10 @@ public class V1CamelScheduledPollConsumer extends V1BaseCamelModel
      */
     public V1CamelScheduledPollConsumer(QName qname) {
         super(qname);
+
+        setModelChildrenOrder(INITIAL_DELAY, DELAY, USE_FIXED_DELAY,
+            TIME_UNIT, SEND_EMPTY_MESSAGE_WHEN_IDLE
+        );
     }
 
     /**
@@ -74,10 +78,6 @@ public class V1CamelScheduledPollConsumer extends V1BaseCamelModel
      */
     public V1CamelScheduledPollConsumer(Configuration config, Descriptor desc) {
         super(config, desc);
-
-        setModelChildrenOrder(INITIAL_DELAY, DELAY, USE_FIXED_DELAY,
-            TIME_UNIT, SEND_EMPTY_MESSAGE_WHEN_IDLE
-        );
     }
 
     /**

--- a/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
+++ b/camel/camel-core/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
@@ -49,6 +49,7 @@ import org.switchyard.component.camel.config.model.file.v1.V1CamelFileBindingMod
 import org.switchyard.component.camel.config.model.ftp.v1.V1CamelFtpBindingModel;
 import org.switchyard.component.camel.config.model.ftps.v1.V1CamelFtpsBindingModel;
 import org.switchyard.component.camel.config.model.jms.v1.V1CamelJmsBindingModel;
+import org.switchyard.component.camel.config.model.mail.v1.V1CamelMailBindingModel;
 import org.switchyard.component.camel.config.model.mock.v1.V1CamelMockBindingModel;
 import org.switchyard.component.camel.config.model.netty.v1.V1CamelNettyTcpBindingModel;
 import org.switchyard.component.camel.config.model.netty.v1.V1CamelNettyUdpBindingModel;
@@ -99,7 +100,8 @@ public class CamelActivator extends BaseActivator {
         V1CamelTimerBindingModel.TIMER,
         V1CamelJmsBindingModel.JMS,
         V1CamelQuartzBindingModel.QUARTZ,
-        V1CamelSqlBindingModel.SQL
+        V1CamelSqlBindingModel.SQL,
+        V1CamelMailBindingModel.MAIL
     };
 
     private SwitchYardCamelContext _camelContext;

--- a/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
+++ b/camel/camel-core/src/main/resources/org/switchyard/component/camel/config/model/v1/camel-v1.xsd
@@ -169,6 +169,49 @@ MA  02110-1301, USA.
         </complexContent>
     </complexType>
 
+    <element name="binding.mail" type="camel:CamelMailBindingType" substitutionGroup="swyd:binding.switchyard"/>
+    <complexType name="CamelMailBindingType">
+        <complexContent>
+            <extension base="camel:BaseCamelBinding">
+                <sequence>
+                    <element name="host" type="string" />
+                    <element name="port" type="int" minOccurs="0" maxOccurs="1"/>
+                    <element name="username" type="string" minOccurs="0" maxOccurs="1"/>
+                    <element name="password" type="string" minOccurs="0" maxOccurs="1"/>
+                    <element name="connectionTimeout" type="integer" minOccurs="0" maxOccurs="1"/>
+                    <element name="consume" type="camel:CamelMailConsumerType" minOccurs="0" maxOccurs="1"/>
+                    <element name="produce" type="camel:CamelMailProducerType" minOccurs="0" maxOccurs="1"/>
+                </sequence>
+                <attribute name="secure" type="boolean"/>
+            </extension>
+        </complexContent>
+    </complexType>
+    <complexType name="CamelMailProducerType">
+        <sequence>
+            <element name="subject" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="from" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="to" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="CC" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="BCC" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="replyTo" type="string" minOccurs="0" maxOccurs="1"/>
+        </sequence>
+    </complexType>
+    <complexType name="CamelMailConsumerType">
+        <complexContent>
+            <extension base="camel:ScheduledBatchPollConsumerType">
+                <sequence>
+                    <element name="folderName" type="string" minOccurs="0" maxOccurs="1"/>
+                    <element name="fetchSize" type="integer" minOccurs="0" maxOccurs="1"/>
+                    <element name="unseen" type="boolean" minOccurs="0" maxOccurs="1"/>
+                    <element name="delete" type="boolean" minOccurs="0" maxOccurs="1"/>
+                    <element name="copyTo" type="string" minOccurs="0" maxOccurs="1"/>
+                    <element name="disconnect" type="boolean" minOccurs="0" maxOccurs="1"/>
+                </sequence>
+                <attribute name="accountType" type="camel:MailConsumerAccountType" default="imap"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
     <element name="binding.mock" type="camel:CamelMockBindingType" substitutionGroup="swyd:binding.switchyard"/>
     <complexType name="CamelMockBindingType" >
         <complexContent>
@@ -443,6 +486,13 @@ MA  02110-1301, USA.
             <enumeration value="MINUTES" />
             <enumeration value="HOURS" />
             <enumeration value="DAYS" />
+        </restriction>
+    </simpleType>
+
+    <simpleType name="MailConsumerAccountType">
+        <restriction base="string">
+            <enumeration value="imap" />
+            <enumeration value="pop3" />
         </restriction>
     </simpleType>
 

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailBindingModelTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailBindingModelTest.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import org.apache.camel.component.mail.MailEndpoint;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Test;
+import org.switchyard.component.camel.config.model.mail.CamelMailBindingModel;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelModelTest;
+import org.switchyard.config.model.Validation;
+
+/**
+ * Test for {@link V1CamelMailBindingModel}.
+ */
+public class V1CamelMailBindingModelTest extends V1BaseCamelModelTest<V1CamelMailBindingModel> {
+
+    private static final String CAMEL_XML = "switchyard-mail-binding-beans.xml";
+    private static final Boolean SECURE = true;
+
+    private static final String HOST = "localhost";
+    private static final Integer PORT = 233;
+    private static final String USERNAME = "camel";
+    private static final String PASSWORD = "rider";
+    private static final Integer CONNECTION_TIMEOUT = 300;
+    private static final String CAMEL_URI = "imaps://localhost:233?connectionTimeout=300&"
+        + "password=rider&unseen=true&username=camel";
+
+    @Test
+    public void validateCamelBindingModelWithBeanElement() throws Exception {
+        final V1CamelMailBindingModel bindingModel = getFirstCamelBinding(CAMEL_XML);
+        final Validation validateModel = bindingModel.validateModel();
+
+        validateModel.assertValid();
+        assertTrue(validateModel.isValid());
+        assertEquals(SECURE, bindingModel.isSecure());
+        assertEquals(HOST, bindingModel.getHost());
+        assertEquals(PORT, bindingModel.getPort());
+        assertEquals(USERNAME, bindingModel.getUsername());
+        assertEquals(PASSWORD, bindingModel.getPassword());
+        assertEquals(CONNECTION_TIMEOUT, bindingModel.getConnectionTimeout());
+    }
+
+    @Test
+    public void compareWriteConfig() throws Exception {
+        String refXml = getFirstCamelBinding(CAMEL_XML).toString();
+        String newXml = createModel().toString();
+        XMLUnit.setIgnoreWhitespace(true);
+        Diff diff = XMLUnit.compareXML(refXml, newXml);
+        assertTrue(diff.toString(), diff.similar());
+    }
+
+    @Test
+    public void testCamelEndpoint()  throws Exception {
+        CamelMailBindingModel model = getFirstCamelBinding(CAMEL_XML);
+
+        MailEndpoint endpoint = getEndpoint(model, MailEndpoint.class);
+        assertEquals(HOST, endpoint.getConfiguration().getHost());
+        assertEquals(CAMEL_URI, endpoint.getEndpointUri().toString());
+    }
+
+    private V1CamelMailBindingModel createModel() {
+        return (V1CamelMailBindingModel) new V1CamelMailBindingModel()
+            .setSecure(SECURE)
+            .setHost(HOST)
+            .setPort(PORT)
+            .setUsername(USERNAME)
+            .setPassword(PASSWORD)
+            .setConnectionTimeout(CONNECTION_TIMEOUT)
+            .setConsumer(new V1CamelMailConsumerBindingModel().setUnseen(true))
+        ;
+    }
+
+}

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailConsumerBindingModelTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailConsumerBindingModelTest.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import org.apache.camel.component.mail.MailEndpoint;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Test;
+import org.switchyard.component.camel.config.model.mail.CamelMailConsumerBindingModel;
+import org.switchyard.component.camel.config.model.mail.v1.V1CamelMailConsumerBindingModel.AccountType;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelModelTest;
+import org.switchyard.config.model.Validation;
+
+/**
+ * Test for {@link V1CamelMailBindingModel} with {@link V1CamelMailConsumerBindingModel} set.
+ */
+public class V1CamelMailConsumerBindingModelTest extends V1BaseCamelModelTest<V1CamelMailBindingModel> {
+
+    private static final String CAMEL_XML = "switchyard-mail-binding-consumer-beans.xml";
+
+    private static final String HOST = "localhost";
+    private static final Boolean SECURE = true;
+
+    private static final String FOLDER_NAME = "Mail/Inbox";
+    private static final Integer FETCH_SIZE = 10;
+    private static final Boolean UNSEEN = false;
+    private static final Boolean DELETE = true;
+    private static final String COPY_TO = "SEEN";
+    private static final Boolean DISCONNECT = true;
+    private static final String ACCOUNT_TYPE = AccountType.pop3.name();
+
+    private static final String CAMEL_URI = "pop3s://localhost?folderName=Mail/Inbox&fetchSize=10&unseen=false&delete=true&copyTo=SEEN&disconnect=true";
+
+    @Test
+    public void testConfigOverride() {
+        // set a value on an existing config element
+        V1CamelMailBindingModel bindingModel = createModel();
+
+        bindingModel.getConsumer().setFetchSize(2500);
+        assertEquals(new Integer(2500), bindingModel.getConsumer().getFetchSize());
+    }
+
+    @Test
+    public void testReadConfig() throws Exception {
+        final V1CamelMailBindingModel bindingModel = getFirstCamelBinding(CAMEL_XML);
+        final Validation validateModel = bindingModel.validateModel();
+        //Valid Model?
+        assertTrue(validateModel.isValid());
+        //Camel File
+        assertEquals(HOST, bindingModel.getHost());
+        assertEquals(SECURE, bindingModel.isSecure());
+        //Camel File Consumer
+        assertConsumerModel(bindingModel.getConsumer());
+        assertEquals(CAMEL_URI, bindingModel.getComponentURI().toString());
+    }
+
+    @Test
+    public void testWriteConfig() throws Exception {
+        V1CamelMailBindingModel bindingModel = createModel();
+        assertEquals(HOST, bindingModel.getHost());
+        assertEquals(SECURE, bindingModel.isSecure());
+        //Camel File Consumer
+        assertConsumerModel(bindingModel.getConsumer());
+        assertEquals(CAMEL_URI, bindingModel.getComponentURI().toString());
+    }
+
+    @Test
+    public void compareWriteConfig() throws Exception {
+        String refXml = getFirstCamelBinding(CAMEL_XML).toString();
+        String newXml = createModel().toString();
+        XMLUnit.setIgnoreWhitespace(true);
+        Diff diff = XMLUnit.compareXML(refXml, newXml);
+        assertTrue(diff.toString(), diff.similar());
+    }
+
+    @Test
+    public void testComponentURI() {
+        V1CamelMailBindingModel bindingModel = createModel();
+        assertEquals(CAMEL_URI, bindingModel.getComponentURI().toString());
+    }
+
+    @Test
+    public void testCamelEndpoint() {
+        V1CamelMailBindingModel model = createModel();
+        MailEndpoint endpoint = getEndpoint(model, MailEndpoint.class);
+
+        assertEquals(HOST, endpoint.getConfiguration().getHost());
+        assertEquals(FOLDER_NAME, endpoint.getConfiguration().getFolderName());
+        assertEquals(FETCH_SIZE.intValue(), endpoint.getConfiguration().getFetchSize());
+        assertEquals(UNSEEN.booleanValue(), endpoint.getConfiguration().isUnseen());
+        assertEquals(DELETE.booleanValue(), endpoint.getConfiguration().isDelete());
+        assertEquals(COPY_TO, endpoint.getConfiguration().getCopyTo());
+        assertEquals(DISCONNECT.booleanValue(), endpoint.getConfiguration().isDisconnect());
+    }
+
+    private V1CamelMailBindingModel createModel() {
+        V1CamelMailBindingModel model = new V1CamelMailBindingModel();
+        model.setSecure(SECURE);
+        model.setHost(HOST);
+
+        CamelMailConsumerBindingModel consumer = new V1CamelMailConsumerBindingModel()
+            .setAccountType(ACCOUNT_TYPE)
+            .setFolderName(FOLDER_NAME)
+            .setFetchSize(FETCH_SIZE)
+            .setUnseen(UNSEEN)
+            .setDelete(DELETE)
+            .setCopyTo(COPY_TO)
+            .setDisconnect(DISCONNECT);
+        model.setConsumer(consumer);
+
+        return model;
+    }
+
+    private void assertConsumerModel(CamelMailConsumerBindingModel consumer) {
+        assertEquals(ACCOUNT_TYPE, consumer.getProtocol());
+        assertEquals(FOLDER_NAME, consumer.getFolderName());
+        assertEquals(FETCH_SIZE, consumer.getFetchSize());
+        assertEquals(UNSEEN, consumer.isUnseen());
+        assertEquals(DELETE, consumer.isDelete());
+        assertEquals(COPY_TO, consumer.getCopyTo());
+        assertEquals(DISCONNECT, consumer.isDisconnect());
+    }
+}

--- a/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailProducerBindingModelTest.java
+++ b/camel/camel-core/src/test/java/org/switchyard/component/camel/config/model/mail/v1/V1CamelMailProducerBindingModelTest.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.config.model.mail.v1;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+import org.apache.camel.component.mail.MailEndpoint;
+import org.apache.camel.util.UnsafeUriCharactersEncoder;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Test;
+import org.switchyard.component.camel.config.model.v1.V1BaseCamelModelTest;
+import org.switchyard.config.model.Validation;
+
+/**
+ * Test for {@link V1CamelMailBindingModel} with {@link V1CamelMailProducerBindingModel} set.
+ */
+public class V1CamelMailProducerBindingModelTest extends V1BaseCamelModelTest<V1CamelMailBindingModel> {
+
+    private static final String CAMEL_XML = "switchyard-mail-binding-producer-beans.xml";
+
+    private static final String HOST = "rider";
+    private static final Boolean SECURE = true;
+    private static final String SUBJECT = "Desert ride";
+    private static final String FROM = "rider@camel";
+    private static final String TO = "camel@rider";
+    private static final String CC = "mule@rider";
+    private static final String BCC = "rider@mule";
+    private static final String REPLY_TO = "camel@camel";
+
+    private static final String CAMEL_URI = UnsafeUriCharactersEncoder.encode(
+        "smtps://rider?subject=Desert ride&from=rider@camel&to=camel@rider" +
+        "&CC=mule@rider&BCC=rider@mule&replyTo=camel@camel"
+    );
+
+    @Test
+    public void testConfigOverride() {
+        // set a value on an existing config element
+        V1CamelMailBindingModel bindingModel = createModel();
+        assertEquals(SUBJECT, bindingModel.getProducer().getSubject());
+        bindingModel.getProducer().setSubject(FROM);
+        assertEquals(FROM, bindingModel.getProducer().getSubject());
+    }
+
+    @Test
+    public void testReadConfig() throws Exception {
+        final V1CamelMailBindingModel bindingModel = getFirstCamelReferenceBinding(CAMEL_XML);
+        final Validation validateModel = bindingModel.validateModel();
+        //Valid Model?
+        validateModel.assertValid();
+        assertTrue(validateModel.isValid());
+        //Camel
+        assertEquals(HOST, bindingModel.getHost());
+        assertEquals(SECURE, bindingModel.isSecure());
+        //Camel Mail Producer
+        assertEquals(SUBJECT, bindingModel.getProducer().getSubject());
+        assertEquals(FROM, bindingModel.getProducer().getFrom());
+        assertEquals(TO, bindingModel.getProducer().getTo());
+        assertEquals(CC, bindingModel.getProducer().getCC());
+        assertEquals(BCC, bindingModel.getProducer().getBCC());
+        assertEquals(REPLY_TO, bindingModel.getProducer().getReplyTo());
+        assertEquals(CAMEL_URI, bindingModel.getComponentURI().toString());
+    }
+
+    /**
+     * This test fails because of namespace prefix 
+     * 
+     */
+    @Test
+    public void testWriteConfig() throws Exception {
+        String refXml = getFirstCamelReferenceBinding(CAMEL_XML).toString();
+        String newXml = createModel().toString();
+        XMLUnit.setIgnoreWhitespace(true);
+        Diff diff = XMLUnit.compareXML(refXml, newXml);
+        assertTrue(diff.toString(), diff.similar()); 
+    }
+
+    @Test
+    public void testComponentURI() throws Exception {
+        V1CamelMailBindingModel bindingModel = getFirstCamelReferenceBinding(CAMEL_XML);
+        assertEquals(CAMEL_URI.toString(), bindingModel.getComponentURI().toString());
+    }
+
+    @Test
+    public void testCamelEndpoint() throws Exception {
+        V1CamelMailBindingModel model = getFirstCamelReferenceBinding(CAMEL_XML);
+        MailEndpoint endpoint = getEndpoint(model, MailEndpoint.class);
+
+        assertEquals(SUBJECT, endpoint.getConfiguration().getSubject());
+        assertEquals(FROM, endpoint.getConfiguration().getFrom());
+        assertEquals(REPLY_TO, endpoint.getConfiguration().getReplyTo());
+    }
+
+    private V1CamelMailBindingModel createModel() {
+        V1CamelMailBindingModel model = new V1CamelMailBindingModel()
+           .setSecure(SECURE)
+           .setHost(HOST);
+
+        V1CamelMailProducerBindingModel producer = new V1CamelMailProducerBindingModel()
+            .setSubject(SUBJECT)
+            .setFrom(FROM)
+            .setTo(TO)
+            .setCC(CC)
+            .setBCC(BCC)
+            .setReplyTo(REPLY_TO);
+        model.setProducer(producer);
+
+        return model;
+    }
+
+}

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-beans.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard 
+    xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:camel="urn:switchyard-component-camel:config:1.0" 
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
+
+    <sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
+        <sca:service name="camelTest" promote="SimpleCamelService">
+            <camel:binding.mail secure="true">
+                <camel:host>localhost</camel:host>
+                <camel:port>233</camel:port>
+                <camel:username>camel</camel:username>
+                <camel:password>rider</camel:password>
+                <camel:connectionTimeout>300</camel:connectionTimeout>
+                <camel:consume>
+                    <camel:unseen>true</camel:unseen>
+                </camel:consume>
+            </camel:binding.mail>
+        </sca:service>
+    </sca:composite>
+
+</switchyard>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-consumer-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-consumer-beans.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard 
+    xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:camel="urn:switchyard-component-camel:config:1.0" 
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
+
+    <sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
+        <sca:service name="camelTest" promote="SimpleCamelService">
+            <camel:binding.mail secure="true">
+                <camel:host>localhost</camel:host>
+                <camel:consume accountType="pop3">
+                    <camel:folderName>Mail/Inbox</camel:folderName>
+                    <camel:fetchSize>10</camel:fetchSize>
+                    <camel:unseen>false</camel:unseen>
+                    <camel:delete>true</camel:delete>
+                    <camel:copyTo>SEEN</camel:copyTo>
+                    <camel:disconnect>true</camel:disconnect>
+                </camel:consume>
+            </camel:binding.mail>
+        </sca:service>
+    </sca:composite>
+</switchyard>

--- a/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-producer-beans.xml
+++ b/camel/camel-core/src/test/resources/org/switchyard/component/camel/config/model/mail/v1/switchyard-mail-binding-producer-beans.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard 
+    xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:camel="urn:switchyard-component-camel:config:1.0" 
+    xmlns:selector="urn:switchyard-component-common-selector:config:1.0" 
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" >
+
+    <sca:composite name="camelTest" targetNamespace="urn:camel-core:test:1.0">
+        <sca:reference name="mail" multiplicity="0..1" promote="mailTest">
+            <camel:binding.mail secure="true">
+                <camel:host>rider</camel:host>
+                <camel:produce>
+                    <camel:subject>Desert ride</camel:subject>
+                    <camel:from>rider@camel</camel:from>
+                    <camel:to>camel@rider</camel:to>
+                    <camel:CC>mule@rider</camel:CC>
+                    <camel:BCC>rider@mule</camel:BCC>
+                    <camel:replyTo>camel@camel</camel:replyTo>
+                </camel:produce>
+            </camel:binding.mail>
+        </sca:reference>
+    </sca:composite>
+
+</switchyard>


### PR DESCRIPTION
Plus minor change in composer which allows to transfer attachements between camel and switchyard.
