### PR TITLE
SWITCHYARD-1211: Support javax.resource.cci.Streamable as recordClassName in JCA outbound

### DIFF
--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordBindingData.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordBindingData.java
@@ -1,0 +1,49 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.composer;
+
+import org.switchyard.component.jca.processor.cci.StreamableRecord;
+
+/**
+ * Streamable record binding data.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
+ * @author Antti Laisi
+ */
+public class StreamableRecordBindingData implements RecordBindingData<StreamableRecord> {
+
+    private final StreamableRecord _record;
+
+    /**
+     * Constructs a new streamable record binding data with the specified record.
+     * @param record the specified streamable record
+     */
+    public StreamableRecordBindingData(StreamableRecord record) {
+        _record = record;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StreamableRecord getRecord() {
+        return _record;
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapper.java
@@ -1,0 +1,76 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.composer;
+
+import org.switchyard.Context;
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.jca.JCAConstants;
+import org.switchyard.component.jca.processor.cci.StreamableRecord;
+
+/**
+ * ContextMapper for CCI Streamable Record.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ */
+public class StreamableRecordContextMapper extends BaseRegexContextMapper<StreamableRecordBindingData> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void mapFrom(StreamableRecordBindingData source, Context context) throws Exception {
+        StreamableRecord record = source.getRecord();
+        String recordName = record.getRecordName();
+        if (recordName != null) {
+            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.EXCHANGE)
+                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+        }
+        String recordDescription = record.getRecordShortDescription();
+        if (recordDescription != null) {
+            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.EXCHANGE)
+                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void mapTo(Context context, StreamableRecordBindingData target) throws Exception {
+        StreamableRecord record = target.getRecord();
+        for (Property property : context.getProperties(Scope.EXCHANGE)) {
+            String name = property.getName();
+            Object value = property.getValue();
+            if (value == null) {
+                continue;
+            }
+            
+            if (name.equals(JCAConstants.CCI_RECORD_NAME_KEY)) {
+                record.setRecordName(value.toString());
+            } else if (name.equals(JCAConstants.CCI_RECORD_SHORT_DESC_KEY)) {
+                record.setRecordShortDescription(value.toString());
+            }
+        }
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapperFactory.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapperFactory.java
@@ -1,0 +1,49 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.composer;
+
+import org.switchyard.component.common.composer.ContextMapper;
+import org.switchyard.component.common.composer.ContextMapperFactory;
+
+/**
+ * ContextMapperFactory for CCI Streamable Record.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ */
+public class StreamableRecordContextMapperFactory extends ContextMapperFactory<StreamableRecordBindingData> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<StreamableRecordBindingData> getBindingDataClass() {
+        return StreamableRecordBindingData.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContextMapper<StreamableRecordBindingData> newContextMapperDefault() {
+        return new StreamableRecordContextMapper();
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposer.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposer.java
@@ -1,0 +1,64 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.composer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import org.switchyard.Exchange;
+import org.switchyard.Message;
+import org.switchyard.component.common.composer.BaseMessageComposer;
+
+/**
+ * MessageComposer implementation for CCI Streamable Record that is used by JCA component.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ */
+public class StreamableRecordMessageComposer extends BaseMessageComposer<StreamableRecordBindingData> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Message compose(StreamableRecordBindingData source, Exchange exchange, boolean create) throws Exception {
+        final org.switchyard.Message message = create ? exchange.createMessage() : exchange.getMessage();
+        getContextMapper().mapFrom(source, exchange.getContext());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(); 
+        source.getRecord().write(baos);
+        message.setContent(new ByteArrayInputStream(baos.toByteArray()));
+        return message;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StreamableRecordBindingData decompose(Exchange exchange, StreamableRecordBindingData target) throws Exception {
+        getContextMapper().mapTo(exchange.getContext(), target);
+
+        final InputStream content = exchange.getMessage().getContent(InputStream.class);
+        target.getRecord().read(content);
+        return target;
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposerFactory.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposerFactory.java
@@ -1,0 +1,49 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.composer;
+
+import org.switchyard.component.common.composer.MessageComposer;
+import org.switchyard.component.common.composer.MessageComposerFactory;
+
+/**
+ * MessageComposerFactory for CCI Streamable Record.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ */
+public class StreamableRecordMessageComposerFactory extends MessageComposerFactory<StreamableRecordBindingData> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class<StreamableRecordBindingData> getBindingDataClass() {
+        return StreamableRecordBindingData.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public MessageComposer<StreamableRecordBindingData> newMessageComposerDefault() {
+        return new StreamableRecordMessageComposer();
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/processor/CCIProcessor.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/CCIProcessor.java
@@ -95,9 +95,13 @@ public class CCIProcessor extends AbstractOutboundProcessor {
 
             InitialContext ic = new InitialContext();
             _connectionFactory = (ConnectionFactory) ic.lookup(getConnectionFactoryJNDIName());
-            _recordFactory = _connectionFactory.getRecordFactory();
         } catch (Exception e) {
             throw new SwitchYardException("Failed to initialize " + this.getClass().getName(), e);
+        }
+        try {
+            _recordFactory = _connectionFactory.getRecordFactory();
+        } catch (ResourceException e) {
+            _logger.warn("Failed to get RecordFactory: " + e.getMessage());
         }
     }
 

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/RecordHandlerFactory.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/RecordHandlerFactory.java
@@ -20,6 +20,7 @@ package org.switchyard.component.jca.processor.cci;
 
 import javax.resource.cci.IndexedRecord;
 import javax.resource.cci.MappedRecord;
+import javax.resource.cci.Streamable;
 
 import org.switchyard.component.jca.composer.RecordBindingData;
 import org.switchyard.exception.SwitchYardException;
@@ -47,6 +48,8 @@ public final class RecordHandlerFactory {
             return new MappedRecordHandler();
         } else if (recordType.equals(IndexedRecord.class)) {
             return new IndexedRecordHandler();
+        } else if (recordType.equals(Streamable.class)) {
+            return new StreamableRecordHandler();
         } else {
             try {
                 Class<?> clazz = loader.loadClass(RecordHandlerFactory.class.getPackage().getName() + "." + recordType.getSimpleName() + "RecordHandler");

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecord.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecord.java
@@ -1,0 +1,87 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.processor.cci;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+
+import javax.resource.cci.Record;
+import javax.resource.cci.Streamable;
+
+/**
+ * Record for raw byte content.
+ *
+ * @author Antti Laisi
+ */
+public class StreamableRecord implements Streamable, Record {
+
+    private static final long serialVersionUID = 1L;
+
+    private String _recordName;
+    private String _recordShortDescription;
+
+    private byte[] _bytes;
+
+    @Override
+    public String getRecordName() {
+        return _recordName;
+    }
+
+    @Override
+    public String getRecordShortDescription() {
+        return _recordShortDescription;
+    }
+
+    @Override
+    public void setRecordName(String recordName) {
+        _recordName = recordName; 
+    }
+
+    @Override
+    public void setRecordShortDescription(String recordShortDescription) {
+        _recordShortDescription = recordShortDescription;
+    }
+
+    @Override
+    public void read(InputStream in) throws IOException {
+        _bytes = new byte[in.available()];
+        in.read(_bytes);
+    }
+
+    @Override
+    public void write(OutputStream out) throws IOException {
+        if(_bytes != null) {
+            out.write(_bytes);
+        }
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        StreamableRecord clone = new StreamableRecord();
+        clone._recordName = _recordName;
+        clone._recordShortDescription = _recordShortDescription;
+        if(_bytes != null) {
+            clone._bytes = Arrays.copyOf(_bytes, _bytes.length);
+        }
+        return clone;
+    }
+
+}

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecordHandler.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecordHandler.java
@@ -1,0 +1,54 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.processor.cci;
+
+import javax.resource.cci.Connection;
+import javax.resource.cci.Interaction;
+import javax.resource.cci.InteractionSpec;
+import javax.resource.cci.RecordFactory;
+
+import org.switchyard.Exchange;
+import org.switchyard.Message;
+import org.switchyard.component.jca.composer.JCAComposition;
+import org.switchyard.component.jca.composer.StreamableRecordBindingData;
+
+/**
+ * StreamableRecordHandler.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ */
+public class StreamableRecordHandler extends RecordHandler<StreamableRecordBindingData> {
+
+    /**
+     * Constructor.
+     */
+    public StreamableRecordHandler() {
+        setMessageComposer(JCAComposition.getMessageComposer(StreamableRecordBindingData.class));
+    }
+
+    @Override
+    public Message handle(Exchange exchange, RecordFactory factory, InteractionSpec interactionSpec, Connection conn, Interaction interact) throws Exception {
+        StreamableRecord record = new StreamableRecord();
+        StreamableRecord outRecord = new StreamableRecord();
+        interact.execute(interactionSpec, getMessageComposer().decompose(exchange, new StreamableRecordBindingData(record)).getRecord(), outRecord);
+        return getMessageComposer().compose(new StreamableRecordBindingData(outRecord), exchange, true);
+    }
+
+}

--- a/jca/src/main/resources/META-INF/services/org.switchyard.component.common.composer.ContextMapperFactory
+++ b/jca/src/main/resources/META-INF/services/org.switchyard.component.common.composer.ContextMapperFactory
@@ -17,4 +17,5 @@
 #
 org.switchyard.component.jca.composer.MappedRecordContextMapperFactory
 org.switchyard.component.jca.composer.IndexedRecordContextMapperFactory
+org.switchyard.component.jca.composer.StreamableRecordContextMapperFactory
 org.switchyard.component.jca.composer.JMSContextMapperFactory

--- a/jca/src/main/resources/META-INF/services/org.switchyard.component.common.composer.MessageComposerFactory
+++ b/jca/src/main/resources/META-INF/services/org.switchyard.component.common.composer.MessageComposerFactory
@@ -17,4 +17,5 @@
 #
 org.switchyard.component.jca.composer.MappedRecordMessageComposerFactory
 org.switchyard.component.jca.composer.IndexedRecordMessageComposerFactory
+org.switchyard.component.jca.composer.StreamableRecordMessageComposerFactory
 org.switchyard.component.jca.composer.JMSMessageComposerFactory

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReference.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReference.java
@@ -1,0 +1,7 @@
+package org.switchyard.component.jca.deploy;
+
+import java.io.InputStream;
+
+public interface JCACCIStreamReference {
+    public InputStream onMessage(InputStream body);
+}

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceBindingTest.java
@@ -1,0 +1,105 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.jca.deploy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import javax.naming.InitialContext;
+import javax.resource.cci.InteractionSpec;
+import javax.resource.cci.Record;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.jca.processor.cci.StreamableRecord;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.component.test.mixins.jca.InteractionListener;
+import org.switchyard.component.test.mixins.jca.JCAMixIn;
+import org.switchyard.component.test.mixins.jca.MockConnectionFactory;
+import org.switchyard.component.test.mixins.jca.MockManagedConnectionFactory;
+import org.switchyard.component.test.mixins.jca.ResourceAdapterConfig;
+import org.switchyard.test.BeforeDeploy;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+
+/**
+ * Functional test for outbound JCA with streamable record.
+ *
+ * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
+ * @author Antti Laisi
+ *
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(config = "switchyard-outbound-cci-stream-test.xml", mixins = {CDIMixIn.class, JCAMixIn.class})
+public class JCACCIStreamReferenceBindingTest {
+
+    private static final String JNDI_CONNECTION_FACTORY = "java:jboss/MyEISConnectionFactory";
+    private JCAMixIn _jcaMixIn;
+
+    @ServiceOperation("JCACCIStreamReferenceService.onMessage")
+    private Invoker _service;
+
+    @BeforeDeploy
+    public void before() {
+        ResourceAdapterConfig ra = new ResourceAdapterConfig(ResourceAdapterConfig.ResourceAdapterType.MOCK)
+                                        .setName("myeis-ra.rar")
+                                        .addConnectionDefinition(JNDI_CONNECTION_FACTORY, MockManagedConnectionFactory.class.getName());
+        _jcaMixIn.deployResourceAdapters(ra);
+
+        MockConnectionFactory factory = null;
+        try {
+            factory = (MockConnectionFactory) new InitialContext().lookup(JNDI_CONNECTION_FACTORY);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        }
+
+        factory.setInteractionListener(new InteractionListener() {
+            public Record onExecute(InteractionSpec spec, Record input) { return null; }
+            public boolean onExecute(InteractionSpec spec, Record input, Record output) {
+                StreamableRecord in = (StreamableRecord) input;
+                StreamableRecord out = (StreamableRecord) output;
+                try {
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    in.write(baos);
+                    String msg = "Hello, " + new String(baos.toByteArray()) + "!";
+                    out.read(new ByteArrayInputStream(msg.getBytes()));
+                } catch(Exception e) {
+                    e.printStackTrace();
+                    Assert.fail(e.getMessage());
+                }
+                return true;
+            }
+        });
+    }
+
+    @Test
+    public void testOutboundCCI() throws Exception {
+        InputStream payload = new ByteArrayInputStream("Antti".getBytes());
+        InputStream out = _service.sendInOut(payload).getContent(InputStream.class);
+        byte[] name = new byte[out.available()];
+        out.read(name);
+        Assert.assertEquals("Hello, Antti!", new String(name));
+    }
+
+}

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceService.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceService.java
@@ -1,0 +1,7 @@
+package org.switchyard.component.jca.deploy;
+
+import java.io.InputStream;
+
+public interface JCACCIStreamReferenceService {
+    public InputStream onMessage(InputStream body);
+}

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceServiceImpl.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceServiceImpl.java
@@ -1,0 +1,19 @@
+package org.switchyard.component.jca.deploy;
+
+import java.io.InputStream;
+
+import javax.inject.Inject;
+
+import org.switchyard.component.bean.Reference;
+import org.switchyard.component.bean.Service;
+
+@Service(JCACCIStreamReferenceService.class)
+public class JCACCIStreamReferenceServiceImpl implements JCACCIStreamReferenceService {
+    @Inject @Reference
+    private JCACCIStreamReference service;
+
+    @Override
+    public InputStream onMessage(InputStream body) {
+        return service.onMessage(body);
+    }
+}

--- a/jca/src/test/resources/org/switchyard/component/jca/deploy/switchyard-outbound-cci-stream-test.xml
+++ b/jca/src/test/resources/org/switchyard/component/jca/deploy/switchyard-outbound-cci-stream-test.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard 
+    xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
+    xmlns:bean="urn:switchyard-component-bean:config:1.0">
+
+    <sca:composite name="JCACCIStreamTest" targetNamespace="urn:jca:test:1.0">
+    
+        <!-- Reference binding example -->
+        <sca:reference name="JCACCIStreamReference" promote="ComponentName/JCACCIStreamReference" multiplicity="1..1">
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <outboundConnection>
+                   <resourceAdapter name="myeis-ra.rar"/>
+                   <connection jndiName="java:jboss/MyEISConnectionFactory"/>
+               </outboundConnection>
+               <outboundInteraction>
+                   <processor type="org.switchyard.component.jca.processor.CCIProcessor">
+                       <property name="recordClassName" value="javax.resource.cci.Streamable"/>
+                   </processor>
+               </outboundInteraction>
+            </binding.jca>
+        </sca:reference>
+        
+        <sca:component name="ComponentName">
+            <bean:implementation.bean class="org.switchyard.component.jca.deploy.JCACCIReferenceServiceImpl"/>
+            <sca:service name="JCACCIStreamReferenceService">
+                <sca:interface.java interface="org.switchyard.component.jca.deploy.JCACCIStreamReferenceService"/>
+            </sca:service>
+            <sca:reference name="JCACCIStreamReference">
+                <sca:interface.java interface="org.switchyard.component.jca.deploy.JCACCIStreamReference"/>
+            </sca:reference>
+        </sca:component>
+        
+    </sca:composite>
+    
+</switchyard>


### PR DESCRIPTION
Added support for Streamable records by implementing StreamableRecordHandler plus message composer and context mapper. CCIProcessor now also supports resource adapters that don't use a RecordFactory.
