### PR TITLE
SWITCHYARD-1231 operationSelector gets clobbered with multiple camel bindings on a service.

### DIFF
--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/ComponentNameComposer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/ComponentNameComposer.java
@@ -29,6 +29,8 @@ import javax.xml.namespace.QName;
 import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.component.camel.common.SwitchYardRouteDefinition;
 
+import static org.switchyard.component.camel.common.CamelConstants.SWITCHYARD_COMPONENT_NAME;
+
 /**
  * Utility class that takes care of creating Camel component uris for 
  * SwitchYard services.
@@ -36,11 +38,6 @@ import org.switchyard.component.camel.common.SwitchYardRouteDefinition;
  * @author Daniel Bevenius
  */
 public final class ComponentNameComposer {
-
-    /**
-     *Component name used for endpoint URIs.
-     */
-    public static final String SWITCHYARD_COMPONENT_NAME = "switchyard";
 
     private ComponentNameComposer() {
     }

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardComponent.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardComponent.java
@@ -39,12 +39,6 @@ import org.apache.camel.impl.DefaultComponent;
  */
 public class SwitchYardComponent extends DefaultComponent {
 
-    /**
-     * Property added to each Camel Context so that code initialized inside 
-     * Camel can access the SY service domain.
-     */
-    public static final String SERVICE_DOMAIN = "org.switchyard.camel.serviceDomain";
-
     @Override
     protected Endpoint createEndpoint(final String uri, final String path, final Map<String, Object> parameters) throws Exception {
         final String namespace = (String) parameters.remove("namespace");

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -18,6 +18,8 @@
  */
 package org.switchyard.component.camel;
 
+import static org.switchyard.component.camel.ComponentNameComposer.composeSwitchYardServiceName;
+
 import java.util.Set;
 
 import javax.xml.namespace.QName;
@@ -30,15 +32,12 @@ import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.CamelBindingData;
-import org.switchyard.component.camel.common.handler.InboundHandler;
 import org.switchyard.component.common.composer.MessageComposer;
 import org.switchyard.exception.SwitchYardException;
 import org.switchyard.metadata.ServiceOperation;
 import org.switchyard.policy.PolicyUtil;
 import org.switchyard.policy.TransactionPolicy;
 import org.switchyard.selector.OperationSelector;
-
-import static org.switchyard.component.camel.ComponentNameComposer.composeSwitchYardServiceName;
 
 /**
  * A Camel producer that is capable of calling SwitchYard services from a Camel route.
@@ -81,10 +80,9 @@ public class SwitchYardProducer extends DefaultProducer {
         ServiceDomain domain = (ServiceDomain) camelExchange.getContext().getRegistry().lookup(CamelConstants.SERVICE_DOMAIN);
 
         final ServiceReference serviceRef = lookupServiceReference(targetUri, domain);
-        final QName serviceName = serviceRef.getName();
         @SuppressWarnings("unchecked")
-        OperationSelector<CamelBindingData> selector = (OperationSelector<CamelBindingData>) camelExchange.getContext()
-            .getRegistry().lookup(serviceName.toString() + InboundHandler.OPERATION_SELECTOR_REF);
+        OperationSelector<CamelBindingData> selector = (OperationSelector<CamelBindingData>) camelExchange.getIn().getHeader(
+           CamelConstants.OPERATION_SELETOR_HEADER, OperationSelector.class);
 
         if (selector != null) {
             QName op = selector.selectOperation(new CamelBindingData(camelExchange.getIn()));

--- a/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTest.java
+++ b/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTest.java
@@ -35,6 +35,7 @@ import org.switchyard.Exchange;
 import org.switchyard.HandlerException;
 import org.switchyard.Message;
 import org.switchyard.ServiceDomain;
+import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.metadata.InOnlyService;
 import org.switchyard.metadata.InOutService;
@@ -96,7 +97,7 @@ public class SwitchYardComponentTest extends CamelTestSupport {
     @Override 
     protected JndiRegistry createRegistry() {
         JndiRegistry reg = new JndiRegistry();
-        reg.bind(SwitchYardComponent.SERVICE_DOMAIN, _serviceDomain);
+        reg.bind(CamelConstants.SERVICE_DOMAIN, _serviceDomain);
         return reg;
     }
 

--- a/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
+++ b/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
@@ -35,6 +35,7 @@ import org.switchyard.component.camel.ComponentNameComposer;
 import org.switchyard.component.camel.RouteFactory;
 import org.switchyard.component.camel.SwitchYardConsumer;
 import org.switchyard.component.camel.SwitchYardEndpoint;
+import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.CamelComposition;
 import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
 import org.switchyard.component.camel.model.CamelComponentImplementationModel;
@@ -103,7 +104,7 @@ public class CamelActivator extends BaseBindingActivator {
             if (processorDef instanceof ToDefinition) {
                 final ToDefinition to = (ToDefinition) processorDef;
                 final URI componentUri = URI.create(to.getUri());
-                if (componentUri.getScheme().equals(ComponentNameComposer.SWITCHYARD_COMPONENT_NAME)) {
+                if (componentUri.getScheme().equals(CamelConstants.SWITCHYARD_COMPONENT_NAME)) {
                     final String serviceName = componentUri.getHost();
                     final String namespace = ComponentNameComposer.getNamespaceFromURI(componentUri);
                     final QName refServiceName = new QName(namespace, serviceName);

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/CamelConstants.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/CamelConstants.java
@@ -26,9 +26,19 @@ package org.switchyard.component.camel.common;
 public interface CamelConstants {
 
     /**
+     * SwitchYard component scheme.
+     */
+    String SWITCHYARD_COMPONENT_NAME = "switchyard";
+
+    /**
      * Property added to each Camel Context so that code initialized inside 
      * Camel can access the SY service domain.
      */
     String SERVICE_DOMAIN = "org.switchyard.camel.serviceDomain";
+
+    /**
+     * Name of message header where operation selector is stored.
+     */
+    String OPERATION_SELETOR_HEADER = "org.switchyard.operationSelector";
 
 }

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OperationSelectorProcessor.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OperationSelectorProcessor.java
@@ -1,0 +1,67 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.handler;
+
+import static org.switchyard.component.camel.common.CamelConstants.OPERATION_SELETOR_HEADER;
+
+import javax.xml.namespace.QName;
+
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.switchyard.common.lang.Strings;
+import org.switchyard.component.camel.common.composer.CamelBindingData;
+import org.switchyard.component.camel.common.model.CamelBindingModel;
+import org.switchyard.component.common.selector.OperationSelectorFactory;
+import org.switchyard.selector.OperationSelector;
+
+/**
+ * Processor used to choose operation from binding model.
+ */
+public class OperationSelectorProcessor implements Processor {
+
+    private final QName _serviceName;
+    private final CamelBindingModel _bindingModel;
+
+    /**
+     * Creates new processor.
+     * 
+     * @param serviceName Service name.
+     * @param bindingModel Camel binding model bound to service interface.
+     */
+    public OperationSelectorProcessor(QName serviceName, CamelBindingModel bindingModel) {
+        this._serviceName = serviceName;
+        this._bindingModel = bindingModel;
+    }
+
+    @Override
+    public void process(org.apache.camel.Exchange exchange) throws Exception {
+        OperationSelectorFactory<CamelBindingData> selectorFactory = OperationSelectorFactory.getOperationSelectorFactory(CamelBindingData.class);
+        OperationSelector<CamelBindingData> selector = selectorFactory.newOperationSelector(_bindingModel.getOperationSelector());
+
+        if (selector != null) {
+            selector.setDefaultNamespace(Strings.trimToNull(_serviceName.getNamespaceURI()));
+        }
+
+        Message in = exchange.getIn();
+        in.setHeader(OPERATION_SELETOR_HEADER, selector);
+        exchange.setOut(in.copy());
+    }
+
+}
+

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/marshaller/BaseModelMarshaller.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/marshaller/BaseModelMarshaller.java
@@ -2,7 +2,6 @@ package org.switchyard.component.camel.common.marshaller;
 
 import static org.switchyard.config.model.composer.ContextMapperModel.CONTEXT_MAPPER;
 import static org.switchyard.config.model.composer.MessageComposerModel.MESSAGE_COMPOSER;
-import static org.switchyard.config.model.switchyard.SwitchYardModel.DEFAULT_NAMESPACE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,23 +33,6 @@ public class BaseModelMarshaller extends BaseMarshaller {
      */
     private String _namespace;
 
-    private BaseModelMarshaller(Descriptor desc) {
-        super(desc);
-
-        register(DEFAULT_NAMESPACE, CONTEXT_MAPPER, new ModelCreator<Model>() {
-            @Override
-            public V1ContextMapperModel create(Configuration config, Descriptor descriptor) {
-                return new V1ContextMapperModel(config, descriptor);
-            }
-        });
-        register(DEFAULT_NAMESPACE, MESSAGE_COMPOSER, new ModelCreator<Model>() {
-            @Override
-            public V1MessageComposerModel create(Configuration config, Descriptor descriptor) {
-                return new V1MessageComposerModel(config, descriptor);
-            }
-        });
-    }
-
     /**
      * Creates marshaller with given descriptor and bounds by default bindings
      * and other elements to given namespace.
@@ -59,9 +41,21 @@ public class BaseModelMarshaller extends BaseMarshaller {
      * @param defaultNamespace Default namespace of model elements.
      */
     protected BaseModelMarshaller(Descriptor desc, String defaultNamespace) {
-        this(desc);
-
+        super(desc);
         _namespace = defaultNamespace;
+
+        register(_namespace, CONTEXT_MAPPER, new ModelCreator<Model>() {
+            @Override
+            public V1ContextMapperModel create(Configuration config, Descriptor descriptor) {
+                return new V1ContextMapperModel(config, descriptor);
+            }
+        });
+        register(_namespace, MESSAGE_COMPOSER, new ModelCreator<Model>() {
+            @Override
+            public V1MessageComposerModel create(Configuration config, Descriptor descriptor) {
+                return new V1MessageComposerModel(config, descriptor);
+            }
+        });
     }
 
     @Override

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTest.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTest.java
@@ -23,27 +23,17 @@ package org.switchyard.component.camel.common.handler;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.net.URI;
 
-import javax.xml.namespace.QName;
-
 import org.junit.Test;
-import org.switchyard.common.camel.SwitchYardCamelContext;
-import org.switchyard.component.camel.common.model.v1.V1BaseCamelBindingModel;
-import org.switchyard.config.Configuration;
-import org.switchyard.config.model.Descriptor;
 
 /**
  * Unit test for {@link InboundHandler}.
  * 
  * @author Daniel Bevenius
  */
-public class InboundHandlerTest {
-
-    final SwitchYardCamelContext _camelContext = new SwitchYardCamelContext();
-    final Configuration _configuration = mock(Configuration.class);
+public class InboundHandlerTest extends InboundHandlerTestBase {
 
     @Test
     public void reflexive() {
@@ -55,6 +45,7 @@ public class InboundHandlerTest {
     public void symmetric() {
         final InboundHandler x = createInboundHandler("direct://symmetric");
         final InboundHandler y = createInboundHandler("direct://symmetric");
+
         assertThat(x.equals(y), is(true));
         assertThat(y.equals(x), is(true));
     }
@@ -63,7 +54,7 @@ public class InboundHandlerTest {
     public void nonSymmetric() {
         final InboundHandler x = createInboundHandler("direct://symmetric");
         final InboundHandler y = createInboundHandler("direct://nonsymmetric");
-        
+
         assertThat(x.equals(y), is(false));
         assertThat(y.equals(x), is(false));
     }
@@ -119,16 +110,6 @@ public class InboundHandlerTest {
         assertThat(transactedRef, is(equalTo("jtaTransactionMgr")));
         transactedRef = handler.getTransactionManagerName(URI.create("jms://GreetingServiceQueue?connectionFactory=%23&JmsXA&transactionManager=%23jtaTransactionManager"));
         assertThat(transactedRef, is(equalTo("jtaTransactionManager")));
-    }
-
-    private InboundHandler createInboundHandler(final String uri) {
-        final V1BaseCamelBindingModel camelBindingModel = new V1BaseCamelBindingModel(_configuration, new Descriptor()) {
-            @Override
-            public URI getComponentURI() {
-                return URI.create(uri);
-            }
-        };
-        return new InboundHandler(camelBindingModel, _camelContext, new QName("dummyService"));
     }
 
 }

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTestBase.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTestBase.java
@@ -1,0 +1,66 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.handler;
+
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
+
+import javax.xml.namespace.QName;
+
+import org.junit.Before;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.component.camel.common.model.v1.V1BaseCamelBindingModel;
+import org.switchyard.config.Configuration;
+import org.switchyard.config.model.Descriptor;
+import org.switchyard.config.model.selector.OperationSelectorModel;
+
+/**
+ * Base class for inbound handler tests.
+ */
+public abstract class InboundHandlerTestBase {
+
+    protected SwitchYardCamelContext _camelContext;
+    protected Configuration _configuration;
+
+    @Before
+    public void startUp() {
+        _camelContext = new SwitchYardCamelContext(false);
+        _configuration = mock(Configuration.class);
+    }
+
+    protected InboundHandler createInboundHandler(final String uri) {
+        return createInboundHandler(uri, null);
+    }
+
+    protected InboundHandler createInboundHandler(final String uri, final OperationSelectorModel selectorModel) {
+        final V1BaseCamelBindingModel camelBindingModel = new V1BaseCamelBindingModel(_configuration, new Descriptor()) {
+            @Override
+            public URI getComponentURI() {
+                return URI.create(uri);
+            }
+            @Override
+            public OperationSelectorModel getOperationSelector() {
+                return selectorModel;
+            }
+        };
+        return new InboundHandler(camelBindingModel, _camelContext, new QName("urn:foo", "dummyService"));
+    }
+
+}

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/OperationSelectorTest.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/OperationSelectorTest.java
@@ -1,0 +1,74 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.handler;
+
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.component.mock.MockComponent;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.switchyard.config.model.selector.v1.V1StaticOperationSelectorModel;
+import org.switchyard.selector.OperationSelector;
+
+/**
+ * Test of operation selector stuff.
+ */
+public class OperationSelectorTest extends InboundHandlerTestBase {
+
+    @Before
+    public void startUpTest() throws Exception {
+        _camelContext.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        _camelContext.stop();
+    }
+
+    @Test
+    public void operationSelectorProcessor() throws Exception {
+        _camelContext.addComponent("switchyard", new MockComponent());
+        ProducerTemplate producer = _camelContext.createProducerTemplate();
+        InboundHandler handler1 = createInboundHandler("direct://foo", new V1StaticOperationSelectorModel().setOperationName("foo"));
+        InboundHandler handler2 = createInboundHandler("direct://bar", new V1StaticOperationSelectorModel().setOperationName("bar"));
+
+        handler1.start();
+        handler2.start();
+
+        MockEndpoint mockEndpoint = _camelContext.getEndpoint("switchyard://dummyService?namespace=urn:foo", MockEndpoint.class);
+        mockEndpoint.expectedBodiesReceived("FooOperationPayload", "BarOperationPayload");
+        mockEndpoint.expectedMessageCount(2);
+        producer.sendBody("direct://foo", "FooOperationPayload");
+        producer.sendBody("direct://bar", "BarOperationPayload");
+        mockEndpoint.assertIsSatisfied();
+        List<Exchange> exchanges = mockEndpoint.getReceivedExchanges();
+        mockEndpoint.message(0).header(InboundHandler.OPERATION_SELECTOR_REF)
+            .isInstanceOf(OperationSelector.class).matches(exchanges.get(0));
+        mockEndpoint.message(1).header(InboundHandler.OPERATION_SELECTOR_REF)
+            .isInstanceOf(OperationSelector.class).matches(exchanges.get(1));
+
+        handler1.stop();
+        handler2.stop();
+    }
+
+}

--- a/common/common/src/main/java/org/switchyard/component/common/selector/BaseOperationSelector.java
+++ b/common/common/src/main/java/org/switchyard/component/common/selector/BaseOperationSelector.java
@@ -57,6 +57,7 @@ public abstract class BaseOperationSelector<T> implements OperationSelector<T> {
     }
 
     @Override
+
     public QName selectOperation(T content) throws Exception {
         QName operationQName = null;
 


### PR DESCRIPTION
Proposed solution uses dedicated processor put into route created by inbound handler. Other than default bindings can override it.
