### PR TITLE
SWITCHYARD-1251: remove sessionId from BPM component configuration

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/BPMConstants.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/BPMConstants.java
@@ -40,7 +40,7 @@ public final class BPMConstants {
     /** {urn:switchyard-component-bpm:bpm:1.0}sessionId . */
     public static final String SESSION_ID_PROPERTY = new QName(BPM_NAMESPACE, SESSION_ID).toString();
 
-    /** event . */
+    /** signalEvent . */
     public static final String SIGNAL_EVENT = "signalEvent";
     /** {urn:switchyard-component-bpm:bpm:1.0}signalEvent . */
     public static final String SIGNAL_EVENT_PROPERTY = new QName(BPM_NAMESPACE, SIGNAL_EVENT).toString();

--- a/bpm/src/main/java/org/switchyard/component/bpm/annotation/BPM.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/annotation/BPM.java
@@ -53,9 +53,6 @@ public @interface BPM {
     /** Process id. */
     public String processId() default "";
 
-    /** Session id. */
-    public int sessionId() default -1;
-
     /** Channels. */
     public Channel[] channels() default {};
 

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/BPMComponentImplementationModel.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/BPMComponentImplementationModel.java
@@ -64,19 +64,6 @@ public interface BPMComponentImplementationModel extends KnowledgeComponentImple
     public BPMComponentImplementationModel setProcessId(String processId);
 
     /**
-     * Gets the "sessionId" attribute.
-     * @return the "sessionId" attribute
-     */
-    public Integer getSessionId();
-
-    /**
-     * Sets the "sessionId" attribute.
-     * @param sessionId the "sessionId" attribute
-     * @return this instance (useful for chaining)
-     */
-    public BPMComponentImplementationModel setSessionId(Integer sessionId);
-
-    /**
      * Gets the child workItemHandlers model.
      * @return the child workItemHandlers model
      */

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/BPMSwitchYardScanner.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/BPMSwitchYardScanner.java
@@ -133,10 +133,6 @@ public class BPMSwitchYardScanner extends KnowledgeSwitchYardScanner {
             processId = bpmName;
         }
         componentImplementationModel.setProcessId(processId);
-        int sessionId = bpm.sessionId();
-        if (sessionId > -1) {
-            componentImplementationModel.setSessionId(sessionId);
-        }
         ActionsModel actionsModel = new V1ActionsModel(DEFAULT_NAMESPACE);
         JavaService javaService = JavaService.fromClass(bpmInterface);
         for (Method method : bpmClass.getDeclaredMethods()) {

--- a/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BPMComponentImplementationModel.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/config/model/v1/V1BPMComponentImplementationModel.java
@@ -99,25 +99,6 @@ public class V1BPMComponentImplementationModel extends V1KnowledgeComponentImple
      * {@inheritDoc}
      */
     @Override
-    public Integer getSessionId() {
-        String sid = getModelAttribute("sessionId");
-        return sid != null ? Integer.valueOf(sid) : null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public BPMComponentImplementationModel setSessionId(Integer sessionId) {
-        String sid = sessionId != null ? sessionId.toString() : null;
-        setModelAttribute("sessionId", sid);
-        return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public WorkItemHandlersModel getWorkItemHandlers() {
         if (_workItemHandlers == null) {
             _workItemHandlers = (WorkItemHandlersModel)getFirstChildModel(WORK_ITEM_HANDLERS);

--- a/bpm/src/main/java/org/switchyard/component/bpm/exchange/BPMExchangeHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/exchange/BPMExchangeHandler.java
@@ -66,7 +66,6 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
 
     private final boolean _persistent;
     private final String _processId;
-    private final Integer _sessionId;
     private EntityManagerFactory _entityManagerFactory;
 
     /**
@@ -78,7 +77,6 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
         super(model, domain);
         _persistent = model.isPersistent();
         _processId = model.getProcessId();
-        _sessionId = model.getSessionId();
     }
 
     /**
@@ -222,9 +220,6 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
         KnowledgeSession session;
         if (_persistent) {
             Integer sessionId = getInteger(exchange, BPMConstants.SESSION_ID_PROPERTY);
-            if (sessionId == null) {
-                sessionId = _sessionId;
-            }
             session = getPersistentSession(sessionId);
         } else {
             session = getStatefulSession();

--- a/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
+++ b/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
@@ -42,7 +42,6 @@ MA  02110-1301, USA.
                 </sequence>
                 <attribute name="persistent" type="boolean" use="optional"/>
                 <attribute name="processId" type="string" use="optional"/>
-                <attribute name="sessionId" type="integer" use="optional"/>
             </extension>
         </complexContent>
     </complexType>

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/BPMModelTests.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/BPMModelTests.java
@@ -117,7 +117,6 @@ public class BPMModelTests {
         Assert.assertEquals("bpm", bpm.getType());
         Assert.assertTrue(bpm.isPersistent());
         Assert.assertEquals("theProcessId", bpm.getProcessId());
-        Assert.assertEquals(42, bpm.getSessionId().intValue());
         ActionModel action = bpm.getActions().getActions().get(0);
         Assert.assertEquals("theId", action.getId());
         Assert.assertEquals("process", action.getOperation());

--- a/bpm/src/test/java/org/switchyard/component/bpm/config/model/DoStuffProcess.java
+++ b/bpm/src/test/java/org/switchyard/component/bpm/config/model/DoStuffProcess.java
@@ -38,7 +38,6 @@ import org.switchyard.component.common.knowledge.annotation.Resource;
 @BPM(
     persistent=true,
     processId="theProcessId",
-    sessionId=42,
     channels=@Channel(name="theName", operation="theOperation", reference="theReference", value=BPMModelTests.TestChannel.class),
     listeners=@Listener(DebugProcessEventListener.class),
     loggers=@Logger(interval=2000, log="theLog", type=LoggerType.CONSOLE),

--- a/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BPMModelTests-Container.xml
+++ b/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BPMModelTests-Container.xml
@@ -20,7 +20,7 @@ MA  02110-1301, USA.
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="BPMModelTests" targetNamespace="urn:bpm:test:1.0">
         <component name="DoStuffProcess">
-            <implementation.bpm xmlns="urn:switchyard-component-bpm:config:1.0" persistent="true" processId="theProcessId" sessionId="42">
+            <implementation.bpm xmlns="urn:switchyard-component-bpm:config:1.0" persistent="true" processId="theProcessId">
                 <actions>
                     <action id="theId" operation="process" type="SIGNAL_EVENT">
                         <globals>

--- a/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BPMModelTests-Resources.xml
+++ b/bpm/src/test/resources/org/switchyard/component/bpm/config/model/BPMModelTests-Resources.xml
@@ -20,7 +20,7 @@ MA  02110-1301, USA.
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="BPMModelTests" targetNamespace="urn:bpm:test:1.0">
         <component name="DoStuffProcess">
-            <implementation.bpm xmlns="urn:switchyard-component-bpm:config:1.0" persistent="true" processId="theProcessId" sessionId="42">
+            <implementation.bpm xmlns="urn:switchyard-component-bpm:config:1.0" persistent="true" processId="theProcessId">
                 <actions>
                     <action id="theId" operation="process" type="SIGNAL_EVENT">
                         <globals>

--- a/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
+++ b/tools/forge/bpm/src/main/java/org/switchyard/tools/forge/bpm/BPMServicePlugin.java
@@ -18,7 +18,6 @@
  */
 package org.switchyard.tools.forge.bpm;
 
-import static org.switchyard.component.bpm.BPMConstants.SESSION_ID;
 import static org.switchyard.component.bpm.config.model.BPMComponentImplementationModel.DEFAULT_NAMESPACE;
 
 import java.io.File;
@@ -94,7 +93,6 @@ public class BPMServicePlugin implements Plugin {
      * @param argProcessFilePath path to the BPMN process definition
      * @param argProcessId business process id
      * @param argPersistent persistent flag
-     * @param argSessionId session id
      * @param out shell output
      * @throws java.io.IOException error with file resources
      */
@@ -120,10 +118,6 @@ public class BPMServicePlugin implements Plugin {
             name = "persistent",
             description = "The persistent flag")
             final boolean argPersistent,
-            @Option(required = false,
-            name = SESSION_ID,
-            description = "The session id")
-            final Integer argSessionId,
             final PipeOut out)
     throws java.io.IOException {
       
@@ -173,7 +167,7 @@ public class BPMServicePlugin implements Plugin {
         }
         
         // Add the SwitchYard config
-        createImplementationConfig(argServiceName, interfaceClass, processId, argPersistent, argSessionId, processDefinitionPath);
+        createImplementationConfig(argServiceName, interfaceClass, processId, argPersistent, processDefinitionPath);
           
         // Notify user of success
         out.println("Process service " + argServiceName + " has been created.");
@@ -183,7 +177,6 @@ public class BPMServicePlugin implements Plugin {
             String interfaceName,
             String processId,
             boolean persistent,
-            Integer sessionId,
             String processDefinition) {
         
         SwitchYardFacet switchYard = _project.getFacet(SwitchYardFacet.class);
@@ -201,9 +194,6 @@ public class BPMServicePlugin implements Plugin {
         V1BPMComponentImplementationModel bpm = new V1BPMComponentImplementationModel();
         bpm.setProcessId(processId);
         bpm.setPersistent(persistent);
-        if (sessionId != null && sessionId.intValue() > -1) {
-            bpm.setSessionId(sessionId);
-        }
         V1ActionsModel actions = new V1ActionsModel(DEFAULT_NAMESPACE);
         ActionModel action = new V1BPMActionModel().setOperation("operation").setType(BPMActionType.START_PROCESS);
         actions.addAction(action);


### PR DESCRIPTION
SWITCHYARD-1251: remove sessionId from BPM component configuration
https://issues.jboss.org/browse/SWITCHYARD-1251
