### PR TITLE
SWITCHYARD-520 Add support for properties in application configuration

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/Property.java
+++ b/bean/src/main/java/org/switchyard/component/bean/Property.java
@@ -1,0 +1,42 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Property Annotation.
+ * Use this annotation to inject a Property into service bean component.
+ */
+@Target(FIELD)
+@Retention(RUNTIME)
+@Documented
+public @interface Property {
+
+    /**
+     * name of the property.
+     */
+    String name() default "";
+}

--- a/bean/src/main/java/org/switchyard/component/bean/deploy/BeanComponentActivator.java
+++ b/bean/src/main/java/org/switchyard/component/bean/deploy/BeanComponentActivator.java
@@ -21,6 +21,7 @@ package org.switchyard.component.bean.deploy;
 
 import javax.xml.namespace.QName;
 
+import org.switchyard.common.property.PropertyResolver;
 import org.switchyard.component.bean.ClientProxyBean;
 import org.switchyard.component.bean.ServiceProxyHandler;
 import org.switchyard.config.model.composite.ComponentModel;
@@ -69,12 +70,14 @@ public class BeanComponentActivator extends BaseActivator {
             return null;
         }
         
+        PropertyResolver resolver = config.getModelConfiguration().getPropertyResolver();
         for (ServiceDescriptor descriptor : _beanDeploymentMetaData.getServiceDescriptors()) {
             if (descriptor.getServiceName().equals(serviceName.getLocalPart())) {
                 ServiceProxyHandler handler = descriptor.getHandler();
                 for (ComponentReferenceModel reference : config.getReferences()) {
                     handler.addReference(getServiceDomain().getServiceReference(reference.getQName()));
                 }
+                handler.injectImplementationProperties(resolver);
                 return handler;
             }
         }

--- a/bean/src/test/java/org/switchyard/component/bean/tests/BeanPropertyTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/BeanPropertyTest.java
@@ -1,0 +1,51 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.tests;
+
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+
+/*
+ * Assorted methods for testing a CDI bean consuming a service in SwitchYard.
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(config = "BeanPropertyTests.xml", mixins = CDIMixIn.class)
+public class BeanPropertyTest {
+
+    @ServiceOperation("PropertyService.getProperties")
+    private Invoker _invoker;
+
+    @Test
+    public void testBeanProperty() {
+        Map<String,String> response = _invoker.sendInOut(null).getContent(Map.class);
+        Assert.assertEquals("bar", response.get("foo"));
+        Assert.assertEquals("composite.bar", response.get("composite.foo"));
+        Assert.assertEquals("component.bar", response.get("component.foo"));
+    }
+}

--- a/bean/src/test/java/org/switchyard/component/bean/tests/PropertyService.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/PropertyService.java
@@ -1,0 +1,7 @@
+package org.switchyard.component.bean.tests;
+
+import java.util.Map;
+
+public interface PropertyService {
+    Map<String,String> getProperties();
+}

--- a/bean/src/test/java/org/switchyard/component/bean/tests/PropertyServiceBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/PropertyServiceBean.java
@@ -1,0 +1,48 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+
+package org.switchyard.component.bean.tests;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.switchyard.component.bean.Property;
+import org.switchyard.component.bean.Service;
+
+@Service(PropertyService.class)
+public class PropertyServiceBean implements PropertyService {
+    
+    @Property(name="foo")
+    String _foo;
+    
+    @Property(name="composite.foo")
+    String _compositeFoo;
+    
+    @Property(name="component.foo")
+    String _componentFoo;
+    
+    @Override
+    public Map<String,String> getProperties() {
+        Map<String,String> response = new HashMap<String,String>();
+        response.put("foo", _foo);
+        response.put("composite.foo", _compositeFoo);
+        response.put("component.foo", _componentFoo);
+        return response;
+    }
+}

--- a/bean/src/test/resources/org/switchyard/component/bean/tests/BeanPropertyTests.xml
+++ b/bean/src/test/resources/org/switchyard/component/bean/tests/BeanPropertyTests.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+JBoss, Home of Professional Open Source
+Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+as indicated by the @authors tag. All rights reserved.
+See the copyright.txt in the distribution for a
+full listing of individual contributors.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions
+of the GNU Lesser General Public License, v. 2.1.
+This program is distributed in the hope that it will be useful, but WITHOUT A
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+You should have received a copy of the GNU Lesser General Public License,
+v.2.1 along with this distribution; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA  02110-1301, USA.
+-->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+            xmlns:bean="urn:switchyard-component-bean:config:1.0">
+    <sca:composite name="BeanPropertyTest" targetNamespace="urn:bean:test:1.0">
+        <sca:component name="PropertyService">
+            <bean:implementation.bean class="org.switchyard.component.bean.tests.PropertyServiceBean"/>
+            <sca:service name="PropertyService">
+                <sca:interface.java interface="org.switchyard.component.bean.tests.PropertyService"/>
+            </sca:service>
+            <sca:property name="foo" value="(component) should be overridden by domain property"/>
+            <sca:property name="composite.foo" value="(component) should be overridden by composite property"/>
+            <sca:property name="component.foo" value="component.bar"/>
+        </sca:component>
+        <sca:property name="foo" value="(composite) should be overridden by domain property"/>
+        <sca:property name="composite.foo" value="composite.bar"/>
+    </sca:composite>
+    <domain>
+        <properties>
+            <property name="foo" value="bar"/>
+        </properties>
+    </domain>
+</switchyard>

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardPropertiesParser.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardPropertiesParser.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *  *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel;
+
+import java.util.Properties;
+
+import org.apache.camel.component.properties.DefaultPropertiesParser;
+import org.switchyard.common.property.PropertyResolver;
+
+/**
+ * A custom Camel PropertiesParser which resolves SwitchYard implementation properties.
+ */
+public class SwitchYardPropertiesParser extends DefaultPropertiesParser {
+
+    private PropertyResolver _resolver;
+    
+    /**
+     * Constructor.
+     * @param pr PropertyResolver which resolves SwitchYard implementation properties
+     */
+    public SwitchYardPropertiesParser(PropertyResolver pr) {
+        _resolver = pr;
+    }
+    
+     @Override
+     public String parseProperty(String key, String value, Properties properties) {
+         if (_resolver != null) {
+             Object response = _resolver.resolveProperty(key);
+             if (response != null) {
+                 return response.toString();
+             }
+         }
+         
+         return super.parseProperty(key, value, properties);
+     }
+}

--- a/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
+++ b/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
@@ -25,16 +25,19 @@ import java.util.List;
 
 import javax.xml.namespace.QName;
 
+import org.apache.camel.component.properties.PropertiesComponent;
 import org.apache.camel.model.FromDefinition;
 import org.apache.camel.model.ProcessorDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.switchyard.ServiceReference;
 import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.common.property.PropertyResolver;
 import org.switchyard.component.camel.ComponentNameComposer;
 import org.switchyard.component.camel.RouteFactory;
 import org.switchyard.component.camel.SwitchYardConsumer;
 import org.switchyard.component.camel.SwitchYardEndpoint;
+import org.switchyard.component.camel.SwitchYardPropertiesParser;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.CamelComposition;
 import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
@@ -66,6 +69,11 @@ public class CamelActivator extends BaseBindingActivator {
     public ServiceHandler activateService(QName serviceName, ComponentModel config) {
         ServiceHandler handler = null;
 
+        // add switchyard property parser to camel PropertiesComponent
+        PropertiesComponent propertiesComponent = getCamelContext().getComponent("properties", PropertiesComponent.class);
+        PropertyResolver pr = config.getModelConfiguration().getPropertyResolver();
+        propertiesComponent.setPropertiesParser(new SwitchYardPropertiesParser(pr));
+        
         // process service
         for (ComponentServiceModel service : config.getServices()) {
             if (service.getQName().equals(serviceName)) {

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-impl.xml
@@ -31,6 +31,7 @@
                     <log message="ItemId [${body}]"/>
                     <to uri="switchyard://WarehouseService?operationName=hasItem"/>
                     <log message="Title Name [${body}]"/>
+                    <log message="Properties [{{user.name}}, {{prop.domain}}, {{prop.composite}}, {{prop.component}}]"/>
                 </route>
             </camel:implementation.camel>
             <sca:service name="OrderService" >
@@ -39,7 +40,13 @@
             <sca:reference name="WarehouseService">
                 <sca:interface.java interface="org.switchyard.component.camel.deploy.support.WarehouseService"/>
             </sca:reference>
+            <sca:property name="prop.component" value="prop.component value"/>
         </sca:component>
+        <sca:property name="prop.composite" value="prop.composite value"/>
     </sca:composite>
-
+    <domain>
+        <properties>
+            <property name="prop.domain" value="prop.domain value"/>
+        </properties>
+    </domain>
 </switchyard>


### PR DESCRIPTION
Added implementation property support on bean and camel component. Bean component accepts property injection via @Property annotation, and camel accepts {{property.value}} style expression to reference property.
