### PR TITLE
SWITCHYARD-1258 SOAP binding expects style attribute at binding level.

### DIFF
--- a/soap/src/main/java/org/switchyard/component/soap/util/WSDLUtil.java
+++ b/soap/src/main/java/org/switchyard/component/soap/util/WSDLUtil.java
@@ -53,6 +53,7 @@ import org.switchyard.ExchangePattern;
 import org.switchyard.common.type.Classes;
 import org.switchyard.common.xml.XMLHelper;
 import org.switchyard.component.soap.PortName;
+import org.switchyard.exception.SwitchYardException;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -235,14 +236,44 @@ public final class WSDLUtil {
      * @param port The WSDL port.
      * @return The style, can be 'document' or 'rpc'.
      */
+    @SuppressWarnings("unchecked")
     public static String getStyle(Port port) {
-        String style = DOCUMENT;
-        for (ExtensibilityElement element : (List<ExtensibilityElement>)port.getBinding().getExtensibilityElements()) {
+        String portStyle = null;
+        for (ExtensibilityElement element : (List<ExtensibilityElement>) port.getBinding().getExtensibilityElements()) {
             if (element instanceof SOAPBinding) {
-                style = ((SOAPBinding)element).getStyle().toLowerCase();
+                String bindingStyle = ((SOAPBinding) element).getStyle();
+                if (bindingStyle != null) {
+                    portStyle = bindingStyle.toLowerCase();
+                }
             }
         }
-        return style;
+
+        String operationStyle = null;
+        for (BindingOperation operation : (List<BindingOperation>) port.getBinding().getBindingOperations()) {
+            for (ExtensibilityElement element : (List<ExtensibilityElement>) operation.getExtensibilityElements()) {
+                if (element instanceof SOAPOperation) {
+                    String currentOperationStyle = ((SOAPOperation) element).getStyle();
+                    if (currentOperationStyle != null) {
+                        if (operationStyle != null && !currentOperationStyle.equals(operationStyle)) {
+                            throw new SwitchYardException("Incompatible style of soap operation level bindings detected");
+                        }
+                        operationStyle = currentOperationStyle;
+                    }
+                }
+            }
+        }
+
+        if (operationStyle != null && portStyle != null) {
+            if (!portStyle.equals(operationStyle)) {
+                throw new SwitchYardException("Detected mixing different soap binding style on port type and operation level");
+            }
+            return portStyle;
+        } else if (portStyle != null) {
+            return portStyle;
+        } else if (operationStyle != null){
+            return operationStyle;
+        }
+        return DOCUMENT; //default
     }
 
     /**

--- a/soap/src/test/java/org/switchyard/component/soap/WSDLUtilBindingStyleTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/WSDLUtilBindingStyleTest.java
@@ -1,0 +1,79 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.soap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.wsdl.Port;
+import javax.wsdl.Service;
+import javax.xml.namespace.QName;
+
+import org.junit.Test;
+import org.switchyard.component.soap.util.WSDLUtil;
+import org.switchyard.exception.SwitchYardException;
+
+/**
+ * Test of binding style discovery.
+ */
+public class WSDLUtilBindingStyleTest {
+
+    private static final String TEST_WSDL = "BindingStyleTest.wsdl";
+
+    protected final void assertStyle(String portName, String bindingName, String style) throws Exception {
+        Service service = WSDLUtil.getService(TEST_WSDL, new PortName(portName + ":"));
+
+        assertNotNull(service);
+        assertEquals(service.getQName(), new QName("urn:switchyard-component-soap:test-ws:1.0", portName));
+        Port port = WSDLUtil.getPort(service, new PortName(bindingName));
+        assertNotNull(port);
+        assertEquals(style, WSDLUtil.getStyle(port));
+    }
+
+    @Test
+    public void testSoapDocumentBinding() throws Exception {
+        assertStyle("DocumentBindingService", "DocumentBinding", WSDLUtil.DOCUMENT);
+    }
+
+    @Test
+    public void testSoapRpcBinding() throws Exception {
+        assertStyle("RpcBindingService", "RpcBinding", "rpc");
+    }
+
+    @Test
+    public void testOperationRpcBinding() throws Exception {
+        assertStyle("OperationRpcBindingService", "OperationRpcBinding", "rpc");
+    }
+
+    @Test(expected = SwitchYardException.class)
+    public void testDocumentRpcMixedOperationsBinding() throws Exception {
+        assertStyle("DocumentRpcMixedOperationsService", "DocumentRpcMixedOperationsBinding", null);
+    }
+
+    @Test(expected = SwitchYardException.class)
+    public void testRpcDocumentMixedOperationsBinding() throws Exception {
+        assertStyle("RpcDocumentMixedOperationsService", "RpcDocumentMixedOperationsBinding", null);
+    }
+
+    @Test(expected = SwitchYardException.class)
+    public void testRpcDocument2MixedOperationsBinding() throws Exception {
+        assertStyle("RpcDocument2MixedOperationsService", "RpcDocument2MixedOperationsBinding", null);
+    }
+
+}

--- a/soap/src/test/resources/BindingStyleTest.wsdl
+++ b/soap/src/test/resources/BindingStyleTest.wsdl
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<definitions 
+    targetNamespace="urn:switchyard-component-soap:test-ws:1.0" 
+    xmlns="http://schemas.xmlsoap.org/wsdl/" 
+    xmlns:tns="urn:switchyard-component-soap:test-ws:1.0"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+
+  <types>
+    <xsd:schema 
+        targetNamespace="urn:switchyard-component-soap:test-ws:1.0" 
+        xmlns:tns="urn:switchyard-component-soap:test-ws:1.0" 
+        xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="order" type="tns:order"/>
+        <xs:complexType name="order">
+            <xs:sequence>
+                <xs:element name="orderId" type="xs:string"/>
+                <xs:element name="itemId" type="xs:string"/>
+                <xs:element name="quantity" type="xs:int"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:element name="orderAck" type="tns:orderAck"/>
+        <xs:complexType name="orderAck">
+            <xs:sequence>
+                <xs:element name="orderId" type="xs:string"/>
+                <xs:element name="accepted" type="xs:boolean"/>
+                <xs:element name="status" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xsd:schema>
+  </types>
+
+  <message name="submitOrder">
+    <part name="param" element="tns:order"/>
+  </message>
+  <message name="submitOrderResponse">
+    <part name="return" element="tns:orderAck"/>
+  </message>
+
+  <portType name="OrderService">
+    <operation name="submitOrder">
+      <input message="tns:submitOrder"/>
+      <output message="tns:submitOrderResponse"/>
+    </operation>
+  </portType>
+
+  <binding name="OperationRpcBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="submitOrder">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="rpc"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <binding name="RpcBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc" />
+    <operation name="submitOrder">
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <binding name="DocumentRpcMixedOperationsBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="submitOrder">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="submitOrderX">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="rpc"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <binding name="RpcDocumentMixedOperationsBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="rpc" />
+    <operation name="submitOrder">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="submitOrderX">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="rpc"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <binding name="RpcDocument2MixedOperationsBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="submitOrder">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="rpc"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="submitOrderX">
+      <soap:operation soapAction="urn:switchyard-component-soap:test-ws:1.0" style="document" />
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <binding name="DocumentBinding" type="tns:OrderService">
+    <soap:binding transport="http://schemas.xmlsoap.org/soap/http" />
+    <operation name="submitOrder">
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+
+  <service name="OperationRpcBindingService">
+    <port name="OperationRpcBinding" binding="tns:OperationRpcBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+  <service name="RpcBindingService">
+    <port name="RpcBinding" binding="tns:RpcBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+  <service name="DocumentBindingService">
+    <port name="DocumentBinding" binding="tns:DocumentBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+  <service name="DocumentRpcMixedOperationsService">
+    <port name="DocumentRpcMixedOperationsBinding" binding="tns:DocumentRpcMixedOperationsBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+  <service name="RpcDocumentMixedOperationsService">
+    <port name="RpcDocumentMixedOperationsBinding" binding="tns:RpcDocumentMixedOperationsBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+  <service name="RpcDocument2MixedOperationsService">
+    <port name="RpcDocument2MixedOperationsBinding" binding="tns:RpcDocument2MixedOperationsBinding">
+      <soap:address location="http://localhost:18001/OrderService"/>
+    </port>
+  </service>
+</definitions>


### PR DESCRIPTION
This fix allows to specify binding at operation level and disallow mixing of different binding styles.
