### PR TITLE
SWITCHYARD-1305: Incorrect Scope determined in CamelContextMapper

### DIFF
--- a/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelContextMapper.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelContextMapper.java
@@ -50,7 +50,7 @@ public class CamelContextMapper extends BaseRegexContextMapper<CamelBindingData>
         Scope scope;
         Message message = source.getMessage();
         Exchange exchange = message.getExchange();
-        if (exchange.getIn() == source) {
+        if (exchange.getIn() == message) {
             scope = IN;
         } else {
             scope = OUT;


### PR DESCRIPTION
SWITCHYARD-1305: Incorrect Scope determined in CamelContextMapper
https://issues.jboss.org/browse/SWITCHYARD-1305
