### PR TITLE
SWITCHYARD-1345: Context properties not scoped or labeled properly in ContextMappers

### DIFF
--- a/bpel/pom.xml
+++ b/bpel/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-common</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>

--- a/bpel/src/main/java/org/switchyard/component/bpel/riftsaw/RiftsawBPELExchangeHandler.java
+++ b/bpel/src/main/java/org/switchyard/component/bpel/riftsaw/RiftsawBPELExchangeHandler.java
@@ -41,6 +41,7 @@ import org.switchyard.Scope;
 import org.switchyard.component.bpel.BPELFault;
 import org.switchyard.component.bpel.config.model.BPELComponentImplementationModel;
 import org.switchyard.component.bpel.exchange.BPELExchangeHandler;
+import org.switchyard.component.common.label.EndpointLabel;
 import org.switchyard.exception.SwitchYardException;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -52,9 +53,6 @@ import org.w3c.dom.Node;
 public class RiftsawBPELExchangeHandler extends BaseHandler implements BPELExchangeHandler {
     
     private static final int UNDEPLOY_DELAY = 10000;
-
-    /** Context property label for SOAP message headers. */
-    public static final String SOAP_MESSAGE_HEADER = "soap_message_header";
 
     private static final String VFS_SCHEME = "vfs";
 
@@ -253,10 +251,10 @@ public class RiftsawBPELExchangeHandler extends BaseHandler implements BPELExcha
         Node request = exchange.getMessage().getContent(Node.class);
 
         java.util.Map<String, Object> headers = new HashMap<String, Object>();
-        Iterator<Property> h = exchange.getContext().getProperties(Scope.EXCHANGE).iterator();
+        Iterator<Property> h = exchange.getContext().getProperties(Scope.IN).iterator();
         while (h.hasNext()) {
             Property p = h.next();
-            if (p.hasLabel(SOAP_MESSAGE_HEADER)) {
+            if (p.hasLabel(EndpointLabel.SOAP.label())) {
                 headers.put(p.getName(), p.getValue());
             }
         }
@@ -290,7 +288,7 @@ public class RiftsawBPELExchangeHandler extends BaseHandler implements BPELExcha
                 // Set header parts for a response message
                 Set<String> keys = headers.keySet(); // headers are set by invoke method !!!
                 for (String key : keys) {
-                    exchange.getContext().setProperty(key,headers.get(key)).addLabels(SOAP_MESSAGE_HEADER);
+                    exchange.getContext().setProperty(key,headers.get(key), Scope.OUT).addLabels(EndpointLabel.SOAP.label());
                 }
 
                 exchange.send(message);

--- a/bpel/src/main/java/org/switchyard/component/bpel/riftsaw/RiftsawServiceLocator.java
+++ b/bpel/src/main/java/org/switchyard/component/bpel/riftsaw/RiftsawServiceLocator.java
@@ -32,11 +32,13 @@ import org.switchyard.Exchange;
 import org.switchyard.ExchangeState;
 import org.switchyard.HandlerException;
 import org.switchyard.Message;
+import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
 import org.switchyard.SynchronousInOutHandler;
 import org.switchyard.component.bpel.BPELFault;
 import org.switchyard.component.bpel.config.model.BPELComponentImplementationModel;
+import org.switchyard.component.common.label.EndpointLabel;
 import org.switchyard.config.model.composite.ComponentReferenceModel;
 import org.switchyard.exception.DeliveryException;
 import org.switchyard.exception.SwitchYardException;
@@ -258,7 +260,7 @@ public class RiftsawServiceLocator implements ServiceLocator {
             if (headers != null) {
                 Set<String> keys = headers.keySet();
                 for (String key : keys) {
-                    exchange.getContext().setProperty(key,headers.get(key)).addLabels(RiftsawBPELExchangeHandler.SOAP_MESSAGE_HEADER);
+                    exchange.getContext().setProperty(key,headers.get(key), Scope.IN).addLabels(EndpointLabel.SOAP.label());
                 }
             }
             exchange.send(req);

--- a/bpm/src/main/java/org/switchyard/component/bpm/exchange/BPMExchangeHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/exchange/BPMExchangeHandler.java
@@ -219,7 +219,7 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
     private KnowledgeSession getBPMSession(Exchange exchange) {
         KnowledgeSession session;
         if (_persistent) {
-            Integer sessionId = getInteger(exchange, BPMConstants.SESSION_ID_PROPERTY);
+            Integer sessionId = getInteger(exchange, BPMConstants.SESSION_ID_PROPERTY, Scope.IN);
             session = getPersistentSession(sessionId);
         } else {
             session = getStatefulSession();
@@ -229,11 +229,11 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
     }
 
     private Long getProcessInstanceId(Exchange exchange) {
-        return getLong(exchange, BPMConstants.PROCESSS_INSTANCE_ID_PROPERTY);
+        return getLong(exchange, BPMConstants.PROCESSS_INSTANCE_ID_PROPERTY, Scope.IN);
     }
 
     private Object getSignalEvent(Exchange exchange) {
-        Object signalEvent = getObject(exchange, BPMConstants.SIGNAL_EVENT_PROPERTY);
+        Object signalEvent = getObject(exchange, BPMConstants.SIGNAL_EVENT_PROPERTY, Scope.IN);
         if (signalEvent == null) {
             signalEvent = exchange.getMessage().getContent();
         }
@@ -241,7 +241,7 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
     }
 
     private String getSignalId(Exchange exchange, KnowledgeAction action) {
-        String signalId = getString(exchange, BPMConstants.SIGNAL_ID_PROPERTY);
+        String signalId = getString(exchange, BPMConstants.SIGNAL_ID_PROPERTY, Scope.IN);
         if (signalId == null) {
             signalId = action.getId();
         }
@@ -253,13 +253,13 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
         Context context = exchange.getContext();
         Integer sessionId = session.getId();
         if (sessionId != null && sessionId.intValue() > 0) {
-            context.setProperty(BPMConstants.SESSION_ID_PROPERTY, sessionId, Scope.EXCHANGE);
+            context.setProperty(BPMConstants.SESSION_ID_PROPERTY, sessionId, Scope.OUT);
         }
         Map<String, Object> expressionVariables = new HashMap<String, Object>();
         if (processInstance != null) {
             long processInstanceId = processInstance.getId();
             if (processInstanceId > 0) {
-                context.setProperty(BPMConstants.PROCESSS_INSTANCE_ID_PROPERTY, Long.valueOf(processInstanceId), Scope.EXCHANGE);
+                context.setProperty(BPMConstants.PROCESSS_INSTANCE_ID_PROPERTY, Long.valueOf(processInstanceId), Scope.OUT);
             }
             if (processInstance instanceof WorkflowProcessInstanceImpl) {
                 Map<String, Object> processInstanceVariables = ((WorkflowProcessInstanceImpl)processInstance).getVariables();
@@ -276,7 +276,7 @@ public class BPMExchangeHandler extends KnowledgeExchangeHandler<BPMComponentImp
                 if (KnowledgeConstants.CONTENT_OUTPUT.equals(key)) {
                     outputMessage.setContent(value);
                 } else {
-                    context.setProperty(key, value, Scope.EXCHANGE);
+                    context.setProperty(key, value, Scope.OUT);
                 }
             }
         }

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelComposition.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelComposition.java
@@ -31,12 +31,6 @@ import org.switchyard.config.model.composer.MessageComposerModel;
  */
 public final class CamelComposition {
 
-    /** The "camel_exchange_property" context property label. */
-    public static final String CAMEL_EXCHANGE_PROPERTY = "camel_exchange_property";
-
-    /** The "camel_message_header" context property label. */
-    public static final String CAMEL_MESSAGE_HEADER = "camel_message_header";
-
     /**
      * Uses the {@link Composition} class to create a Camel-specific MessageComposer.
      * @return the MessageComposer

--- a/common/common/src/main/java/org/switchyard/component/common/composer/BaseContextMapper.java
+++ b/common/common/src/main/java/org/switchyard/component/common/composer/BaseContextMapper.java
@@ -19,6 +19,7 @@
 package org.switchyard.component.common.composer;
 
 import org.switchyard.Context;
+import org.switchyard.config.model.composer.ContextMapperModel;
 
 /**
  * Base class for ContextMapper, no-op'ing the required methods in case the extender only needs to override one of them.
@@ -28,6 +29,24 @@ import org.switchyard.Context;
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2011 Red Hat Inc.
  */
 public class BaseContextMapper<D extends BindingData> implements ContextMapper<D> {
+
+    private ContextMapperModel _model;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ContextMapperModel getModel() {
+        return _model;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setModel(ContextMapperModel model) {
+        _model = model;
+    }
 
     /**
      * {@inheritDoc}

--- a/common/common/src/main/java/org/switchyard/component/common/composer/ContextMapper.java
+++ b/common/common/src/main/java/org/switchyard/component/common/composer/ContextMapper.java
@@ -19,6 +19,7 @@
 package org.switchyard.component.common.composer;
 
 import org.switchyard.Context;
+import org.switchyard.config.model.composer.ContextMapperModel;
 
 /**
  * Maps context properties from and to a source or target object.
@@ -28,6 +29,18 @@ import org.switchyard.Context;
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2011 Red Hat Inc.
  */
 public interface ContextMapper<D extends BindingData> {
+
+    /**
+     * Gets the model.
+     * @return the model
+     */
+    public ContextMapperModel getModel();
+
+    /**
+     * Sets the model.
+     * @param model the model
+     */
+    public void setModel(ContextMapperModel model);
 
     /**
      * Maps a source object's properties to the context.

--- a/common/common/src/main/java/org/switchyard/component/common/composer/ContextMapperFactory.java
+++ b/common/common/src/main/java/org/switchyard/component/common/composer/ContextMapperFactory.java
@@ -63,6 +63,7 @@ public abstract class ContextMapperFactory<D extends BindingData> {
         ContextMapperFactory<D> contextMapperFactory = ContextMapperFactory.getContextMapperFactory(getBindingDataClass());
         if (model != null) {
             contextMapper = contextMapperFactory.newContextMapper((Class<ContextMapper<D>>)Classes.forName(model.getClazz()));
+            contextMapper.setModel(model);
             if (contextMapper instanceof RegexContextMapper) {
                 RegexContextMapper<D> regexContextMapper = (RegexContextMapper<D>)contextMapper;
                 regexContextMapper.setIncludes(model.getIncludes());

--- a/common/common/src/main/java/org/switchyard/component/common/label/ComponentLabel.java
+++ b/common/common/src/main/java/org/switchyard/component/common/label/ComponentLabel.java
@@ -1,0 +1,74 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.common.label;
+
+import org.switchyard.label.Label;
+
+/**
+ * Represents component labels.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public enum ComponentLabel implements Label {
+
+    /** Component labels. */
+    CAMEL, HORNETQ, HTTP, JCA, RESTEASY, SOAP;
+
+    private final String _label;
+
+    private ComponentLabel() {
+        _label = Label.Util.toSwitchYardLabel("component", name());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String label() {
+        return _label;
+    }
+
+    /**
+     * Gets the ComponentLabel enum via case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the ComponentLabel enum
+     */
+    public static final ComponentLabel ofName(String name) {
+        return Label.Util.ofName(ComponentLabel.class, name);
+    }
+
+    /**
+     * Gets the full-form component label from the case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the full-form component label
+     */
+    public static final String toLabel(String name) {
+        ComponentLabel label = ofName(name);
+        return label != null ? label.label() : null;
+    }
+
+    /**
+     * Prints all known component labels.
+     * @param args ignored
+     */
+    public static void main(String... args) {
+        Label.Util.print(values());
+    }
+
+}

--- a/common/common/src/main/java/org/switchyard/component/common/label/EndpointLabel.java
+++ b/common/common/src/main/java/org/switchyard/component/common/label/EndpointLabel.java
@@ -1,0 +1,74 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.common.label;
+
+import org.switchyard.label.Label;
+
+/**
+ * Represents endpoint labels.
+ *
+ * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2013 Red Hat Inc.
+ */
+public enum EndpointLabel implements Label {
+
+    /** Endpoint labels. */
+    AMQP, ATOM, DIRECT, FILE, FTP, FTPS, HTTP, JCA, JMS, JPA, MAIL, MOCK, QUARTZ, REST, SEDA, SFTP, SOAP, SQL, TCP, TIMER, UDP, URI;
+
+    private final String _label;
+
+    private EndpointLabel() {
+        _label = Label.Util.toSwitchYardLabel("endpoint", name());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String label() {
+        return _label;
+    }
+
+    /**
+     * Gets the EndpointLabel enum via case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the EndpointLabel enum
+     */
+    public static final EndpointLabel ofName(String name) {
+        return Label.Util.ofName(EndpointLabel.class, name);
+    }
+
+    /**
+     * Gets the full-form endpoint label from the case-insensitive short-name.
+     * @param name the case-insensitive short-name
+     * @return the full-form endpoint label
+     */
+    public static final String toLabel(String name) {
+        EndpointLabel label = ofName(name);
+        return label != null ? label.label() : null;
+    }
+
+    /**
+     * Prints all known endpoint labels.
+     * @param args ignored
+     */
+    public static void main(String... args) {
+        Label.Util.print(values());
+    }
+
+}

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/exchange/KnowledgeExchangeHandler.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/exchange/KnowledgeExchangeHandler.java
@@ -25,10 +25,12 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.switchyard.BaseHandler;
+import org.switchyard.Context;
 import org.switchyard.Exchange;
 import org.switchyard.ExchangePhase;
 import org.switchyard.HandlerException;
 import org.switchyard.Property;
+import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
 import org.switchyard.common.lang.Strings;
 import org.switchyard.common.type.Classes;
@@ -241,10 +243,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets a primitive boolean context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected boolean isBoolean(Exchange exchange, String name) {
-        Boolean b = getBoolean(exchange, name);
+    protected boolean isBoolean(Exchange exchange, String name, Scope scope) {
+        Boolean b = getBoolean(exchange, name, scope);
         return b != null && b.booleanValue();
     }
 
@@ -252,10 +255,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets a Boolean context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected Boolean getBoolean(Exchange exchange, String name) {
-        Object value = getObject(exchange, name);
+    protected Boolean getBoolean(Exchange exchange, String name, Scope scope) {
+        Object value = getObject(exchange, name, scope);
         if (value instanceof Boolean) {
             return (Boolean)value;
         } else if (value instanceof String) {
@@ -268,10 +272,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets an Integer context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected Integer getInteger(Exchange exchange, String name) {
-        Object value = getObject(exchange, name);
+    protected Integer getInteger(Exchange exchange, String name, Scope scope) {
+        Object value = getObject(exchange, name, scope);
         if (value instanceof Integer) {
             return (Integer)value;
         } else if (value instanceof Number) {
@@ -286,10 +291,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets a Long context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected Long getLong(Exchange exchange, String name) {
-        Object value = getObject(exchange, name);
+    protected Long getLong(Exchange exchange, String name, Scope scope) {
+        Object value = getObject(exchange, name, scope);
         if (value instanceof Long) {
             return (Long)value;
         } else if (value instanceof Number) {
@@ -304,10 +310,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets a String context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected String getString(Exchange exchange, String name) {
-        Object value = getObject(exchange, name);
+    protected String getString(Exchange exchange, String name, Scope scope) {
+        Object value = getObject(exchange, name, scope);
         if (value instanceof String) {
             return (String)value;
         } else if (value != null) {
@@ -320,10 +327,15 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      * Gets an Object context property.
      * @param exchange the exchange
      * @param name the name
+     * @param scope the scope
      * @return the property
      */
-    protected Object getObject(Exchange exchange, String name) {
-        Property property = exchange.getContext().getProperty(name);
+    protected Object getObject(Exchange exchange, String name, Scope scope) {
+        Context context = exchange.getContext();
+        Property property = context.getProperty(name, scope);
+        if (property == null && !Scope.EXCHANGE.equals(scope)) {
+            property = context.getProperty(name, Scope.EXCHANGE);
+        }
         return property != null ? property.getValue() : null;
     }
 

--- a/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQComposition.java
+++ b/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQComposition.java
@@ -31,9 +31,6 @@ import org.switchyard.config.model.composer.MessageComposerModel;
  */
 public final class HornetQComposition {
 
-    /** The "hornetq_message_property" context property label. */
-    public static final String HORNETQ_MESSAGE_PROPERTY = "hornetq_message_property";
-
     /**
      * Uses the {@link Composition} class to create a HornetQ-specific MessageComposer.
      * @return the MessageComposer

--- a/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQContextMapper.java
+++ b/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQContextMapper.java
@@ -18,15 +18,15 @@
  */
 package org.switchyard.component.hornetq.composer;
 
-import static org.switchyard.Scope.EXCHANGE;
-import static org.switchyard.component.hornetq.composer.HornetQComposition.HORNETQ_MESSAGE_PROPERTY;
-
 import org.hornetq.api.core.PropertyConversionException;
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.api.core.client.ClientMessage;
 import org.switchyard.Context;
 import org.switchyard.Property;
+import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 
 /**
  * HornetQContextMapper.
@@ -34,6 +34,8 @@ import org.switchyard.component.common.composer.BaseRegexContextMapper;
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
 public class HornetQContextMapper extends BaseRegexContextMapper<HornetQBindingData> {
+
+    private static final String[] HORNETQ_LABELS = new String[]{ComponentLabel.HORNETQ.label(), EndpointLabel.JMS.label()};
 
     /**
      * {@inheritDoc}
@@ -46,8 +48,7 @@ public class HornetQContextMapper extends BaseRegexContextMapper<HornetQBindingD
             if (matches(name)) {
                 Object value = clientMessage.getObjectProperty(key);
                 if (value != null) {
-                    // HornetQ ClientMessage properties -> Context EXCHANGE properties
-                    context.setProperty(name, value, EXCHANGE).addLabels(HORNETQ_MESSAGE_PROPERTY);
+                    context.setProperty(name, value, Scope.IN).addLabels(HORNETQ_LABELS);
                 }
             }
         }
@@ -59,13 +60,12 @@ public class HornetQContextMapper extends BaseRegexContextMapper<HornetQBindingD
     @Override
     public void mapTo(Context context, HornetQBindingData target) throws Exception {
         ClientMessage clientMessage = target.getClientMessage();
-        for (Property property : context.getProperties(EXCHANGE)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
             String name = property.getName();
             if (matches(name)) {
                 Object value = property.getValue();
                 if (value != null) {
                     try {
-                        // Context EXCHANGE properties -> HornetQ ClientMessage properties
                         clientMessage.putObjectProperty(name, value);
                     } catch (PropertyConversionException pce) {
                         // ignore and keep going (here just to keep checkstyle happy)

--- a/http/src/main/java/org/switchyard/component/http/composer/HttpBindingData.java
+++ b/http/src/main/java/org/switchyard/component/http/composer/HttpBindingData.java
@@ -23,7 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream; 
+import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -47,8 +47,6 @@ public abstract class HttpBindingData implements BindingData {
     private Map<String, List<String>> _headers;
     private byte[] _body;
     private ContentType _contentType;
-    private ByteArrayInputStream _content;
-    private long _contentLength;
 
     /**
      * Get the HTTP headers map.

--- a/http/src/main/java/org/switchyard/component/http/composer/HttpComposition.java
+++ b/http/src/main/java/org/switchyard/component/http/composer/HttpComposition.java
@@ -33,14 +33,11 @@ import org.switchyard.config.model.composer.MessageComposerModel;
  */
 public final class HttpComposition {
 
-    /** The "http_header" context property label. */
-    public static final String HTTP_HEADER = "http_header";
+    /** The http_request_info property name. */
+    public static final String HTTP_REQUEST_INFO = "http_request_info";
 
-    /** The HTTP status code property name. */
-    public static final String HTTP_STATUS = "status";
-
-    /** The HTTP status code property name. */
-    public static final String HTTP_REQUEST_INFO = "request_info";
+    /** The http_response_status property name. */
+    public static final String HTTP_RESPONSE_STATUS = "http_response_status";
 
     /**
      * Uses the {@link Composition} class to create a HTTP-specific MessageComposer.

--- a/http/src/test/java/org/switchyard/component/http/HttpGatewayTest.java
+++ b/http/src/test/java/org/switchyard/component/http/HttpGatewayTest.java
@@ -34,7 +34,9 @@ import org.switchyard.Exchange;
 import org.switchyard.Message;
 import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
+import org.switchyard.component.http.composer.HttpComposition;
 import org.switchyard.component.http.config.model.HttpBindingModel;
+import org.switchyard.component.test.mixins.http.HTTPMixIn;
 import org.switchyard.config.model.ModelPuller;
 import org.switchyard.config.model.composite.CompositeModel;
 import org.switchyard.config.model.composite.CompositeReferenceModel;
@@ -47,7 +49,6 @@ import org.switchyard.test.Invoker;
 import org.switchyard.test.MockHandler;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
-import org.switchyard.component.test.mixins.http.HTTPMixIn;
 
 /**
  * Contains tests for HTTP Gateway.
@@ -135,7 +136,7 @@ public class HttpGatewayTest {
         Message requestMsg = ex.createMessage().setContent("magesh");
         ex.send(requestMsg);
         handler.waitForOKMessage();
-        Assert.assertEquals(200, ctx.getProperty("status", Scope.IN).getValue());
+        Assert.assertEquals(200, ctx.getProperty(HttpComposition.HTTP_RESPONSE_STATUS, Scope.OUT).getValue());
     }
 
     @Test
@@ -146,7 +147,7 @@ public class HttpGatewayTest {
         Message requestMsg = ex.createMessage().setContent("magesh");
         ex.send(requestMsg);
         handler.waitForFaultMessage();
-        Assert.assertEquals(404, ctx.getProperty("status", Scope.IN).getValue());
+        Assert.assertEquals(404, ctx.getProperty(HttpComposition.HTTP_RESPONSE_STATUS, Scope.OUT).getValue());
     }
 
     private static class HelloInterface extends BaseService {

--- a/jca/src/main/java/org/switchyard/component/jca/composer/IndexedRecordContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/IndexedRecordContextMapper.java
@@ -24,6 +24,8 @@ import org.switchyard.Context;
 import org.switchyard.Property;
 import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 import org.switchyard.component.jca.JCAConstants;
 
 /**
@@ -34,6 +36,8 @@ import org.switchyard.component.jca.JCAConstants;
  */
 public class IndexedRecordContextMapper extends BaseRegexContextMapper<IndexedRecordBindingData> {
 
+    private static final String[] INDEXED_RECORD_LABELS = new String[]{ComponentLabel.JCA.label(), EndpointLabel.JCA.label()};
+
     /**
      * {@inheritDoc}
      */
@@ -42,13 +46,11 @@ public class IndexedRecordContextMapper extends BaseRegexContextMapper<IndexedRe
         IndexedRecord record = source.getRecord();
         String recordName = record.getRecordName();
         if (recordName != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.IN).addLabels(INDEXED_RECORD_LABELS);
         }
         String recordDescription = record.getRecordShortDescription();
         if (recordDescription != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.IN).addLabels(INDEXED_RECORD_LABELS);
         }
     }
 
@@ -59,13 +61,12 @@ public class IndexedRecordContextMapper extends BaseRegexContextMapper<IndexedRe
     @Override
     public void mapTo(Context context, IndexedRecordBindingData target) throws Exception {
         IndexedRecord record = target.getRecord();
-        for (Property property : context.getProperties(Scope.EXCHANGE)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
             String name = property.getName();
             Object value = property.getValue();
             if (value == null) {
                 continue;
             }
-            
             if (name.equals(JCAConstants.CCI_RECORD_NAME_KEY)) {
                 record.setRecordName(value.toString());
             } else if (name.equals(JCAConstants.CCI_RECORD_SHORT_DESC_KEY)) {

--- a/jca/src/main/java/org/switchyard/component/jca/composer/JCAComposition.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/JCAComposition.java
@@ -31,9 +31,6 @@ import org.switchyard.config.model.composer.MessageComposerModel;
  */
 public final class JCAComposition {
 
-    /** The "jca_message_property" context property label. */
-    public static final String JCA_MESSAGE_PROPERTY = "jca_message_property";
-
     /**
      * Uses the {@link Composition} class to create a JCA-specific MessageComposer.
      * @param bindingDataType {@link Class} for binding data type

--- a/jca/src/main/java/org/switchyard/component/jca/composer/JMSContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/JMSContextMapper.java
@@ -27,14 +27,18 @@ import org.switchyard.Context;
 import org.switchyard.Property;
 import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 
 /**
- * JCAJMSContextMapper.
+ * JMSContextMapper.
  *
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
  */
 public class JMSContextMapper extends BaseRegexContextMapper<JMSBindingData> {
+
+    private static final String[] JMS_RECORD_LABELS = new String[]{ComponentLabel.JCA.label(), EndpointLabel.JMS.label()};
 
     /**
      * {@inheritDoc}
@@ -54,9 +58,7 @@ public class JMSContextMapper extends BaseRegexContextMapper<JMSBindingData> {
                     pce.getMessage();
                 }
                 if (value != null) {
-                    // JMS Message properties -> Context EXCHANGE properties
-                    context.setProperty(key, value, Scope.EXCHANGE)
-                            .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+                    context.setProperty(key, value, Scope.IN).addLabels(JMS_RECORD_LABELS);
                 }
             }
         }
@@ -68,13 +70,12 @@ public class JMSContextMapper extends BaseRegexContextMapper<JMSBindingData> {
     @Override
     public void mapTo(Context context, JMSBindingData target) throws Exception {
         Message message = target.getMessage();
-        for (Property property : context.getProperties(Scope.EXCHANGE)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
             String name = property.getName();
             if (matches(name)) {
                 Object value = property.getValue();
                 if (value != null) {
                     try {
-                        // Context EXCHANGE properties -> JMS Message properties
                         message.setObjectProperty(name, value);
                     } catch (Throwable t) {
                         // ignore and keep going (here just to keep checkstyle happy)

--- a/jca/src/main/java/org/switchyard/component/jca/composer/MappedRecordContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/MappedRecordContextMapper.java
@@ -24,6 +24,8 @@ import org.switchyard.Context;
 import org.switchyard.Property;
 import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 import org.switchyard.component.jca.JCAConstants;
 
 /**
@@ -34,6 +36,8 @@ import org.switchyard.component.jca.JCAConstants;
  */
 public class MappedRecordContextMapper extends BaseRegexContextMapper<MappedRecordBindingData> {
 
+    private static final String[] MAPPED_RECORD_LABELS = new String[]{ComponentLabel.JCA.label(), EndpointLabel.JCA.label()};
+
     /**
      * {@inheritDoc}
      */
@@ -42,13 +46,11 @@ public class MappedRecordContextMapper extends BaseRegexContextMapper<MappedReco
         MappedRecord record = source.getRecord();
         String recordName = record.getRecordName();
         if (recordName != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.IN).addLabels(MAPPED_RECORD_LABELS);
         }
         String recordDescription = record.getRecordShortDescription();
         if (recordDescription != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.IN).addLabels(MAPPED_RECORD_LABELS);
         }
     }
 
@@ -59,13 +61,12 @@ public class MappedRecordContextMapper extends BaseRegexContextMapper<MappedReco
     @Override
     public void mapTo(Context context, MappedRecordBindingData target) throws Exception {
         MappedRecord record = target.getRecord();
-        for (Property property : context.getProperties(Scope.EXCHANGE)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
             String name = property.getName();
             Object value = property.getValue();
             if (value == null) {
                 continue;
             }
-            
             if (name.equals(JCAConstants.CCI_RECORD_NAME_KEY)) {
                 record.setRecordName(value.toString());
             } else if (name.equals(JCAConstants.CCI_RECORD_SHORT_DESC_KEY)) {

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapper.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordContextMapper.java
@@ -22,6 +22,8 @@ import org.switchyard.Context;
 import org.switchyard.Property;
 import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 import org.switchyard.component.jca.JCAConstants;
 import org.switchyard.component.jca.processor.cci.StreamableRecord;
 
@@ -34,6 +36,8 @@ import org.switchyard.component.jca.processor.cci.StreamableRecord;
  */
 public class StreamableRecordContextMapper extends BaseRegexContextMapper<StreamableRecordBindingData> {
 
+    private static final String[] STREAMABLE_RECORD_LABELS = new String[]{ComponentLabel.JCA.label(), EndpointLabel.JCA.label()};
+
     /**
      * {@inheritDoc}
      */
@@ -42,13 +46,11 @@ public class StreamableRecordContextMapper extends BaseRegexContextMapper<Stream
         StreamableRecord record = source.getRecord();
         String recordName = record.getRecordName();
         if (recordName != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_NAME_KEY, recordName, Scope.IN).addLabels(STREAMABLE_RECORD_LABELS);
         }
         String recordDescription = record.getRecordShortDescription();
         if (recordDescription != null) {
-            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.EXCHANGE)
-                    .addLabels(JCAComposition.JCA_MESSAGE_PROPERTY);
+            context.setProperty(JCAConstants.CCI_RECORD_SHORT_DESC_KEY, recordDescription, Scope.IN).addLabels(STREAMABLE_RECORD_LABELS);
         }
     }
 
@@ -58,13 +60,12 @@ public class StreamableRecordContextMapper extends BaseRegexContextMapper<Stream
     @Override
     public void mapTo(Context context, StreamableRecordBindingData target) throws Exception {
         StreamableRecord record = target.getRecord();
-        for (Property property : context.getProperties(Scope.EXCHANGE)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
             String name = property.getName();
             Object value = property.getValue();
             if (value == null) {
                 continue;
             }
-            
             if (name.equals(JCAConstants.CCI_RECORD_NAME_KEY)) {
                 record.setRecordName(value.toString());
             } else if (name.equals(JCAConstants.CCI_RECORD_SHORT_DESC_KEY)) {

--- a/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyComposition.java
+++ b/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyComposition.java
@@ -31,9 +31,6 @@ import org.switchyard.config.model.composer.MessageComposerModel;
  */
 public final class RESTEasyComposition {
 
-    /** The "http_header" context property label. */
-    public static final String HTTP_HEADER = "jaxrs_http_header";
-
     /**
      * Uses the {@link Composition} class to create a RESTEasy-specific MessageComposer.
      * @return the MessageComposer

--- a/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyContextMapper.java
+++ b/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyContextMapper.java
@@ -18,10 +18,6 @@
  */
 package org.switchyard.component.resteasy.composer;
 
-import static org.switchyard.Scope.IN;
-import static org.switchyard.Scope.OUT;
-import static org.switchyard.component.resteasy.composer.RESTEasyComposition.HTTP_HEADER;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -29,7 +25,10 @@ import java.util.Map;
 
 import org.switchyard.Context;
 import org.switchyard.Property;
+import org.switchyard.Scope;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
+import org.switchyard.component.common.label.ComponentLabel;
+import org.switchyard.component.common.label.EndpointLabel;
 
 /**
  * RESTEasyContextMapper.
@@ -38,6 +37,8 @@ import org.switchyard.component.common.composer.BaseRegexContextMapper;
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; &copy; 2012 Red Hat Inc.
  */
 public class RESTEasyContextMapper extends BaseRegexContextMapper<RESTEasyBindingData> {
+
+    private static final String[] RESTEASY_LABELS = new String[]{ComponentLabel.RESTEASY.label(), EndpointLabel.REST.label(), EndpointLabel.HTTP.label()};
 
     /**
      * {@inheritDoc}
@@ -51,9 +52,9 @@ public class RESTEasyContextMapper extends BaseRegexContextMapper<RESTEasyBindin
             if (matches(name)) {
                 List<String> values = entry.getValue();
                 if ((values != null) && (values.size() == 1)) {
-                    context.setProperty(name, values.get(0), IN).addLabels(HTTP_HEADER);
+                    context.setProperty(name, values.get(0), Scope.IN).addLabels(RESTEASY_LABELS);
                 } else if ((values != null) && (values.size() > 1)) {
-                    context.setProperty(name, values, IN).addLabels(HTTP_HEADER);
+                    context.setProperty(name, values, Scope.IN).addLabels(RESTEASY_LABELS);
                 }
             }
         }
@@ -63,16 +64,17 @@ public class RESTEasyContextMapper extends BaseRegexContextMapper<RESTEasyBindin
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public void mapTo(Context context, RESTEasyBindingData target) throws Exception {
         Map<String, List<String>> httpHeaders = target.getHeaders();
-        for (Property property : context.getProperties(OUT)) {
-            if (property.hasLabel(HTTP_HEADER)) {
+        for (Property property : context.getProperties(Scope.OUT)) {
+            if (property.hasLabel(EndpointLabel.HTTP.label())) {
                 String name = property.getName();
                 if (matches(name)) {
                     Object value = property.getValue();
                     if (value != null) {
                         if (value instanceof List) {
-                            httpHeaders.put(name, (List)value);
+                            httpHeaders.put(name, (List<String>)value);
                         } else if (value instanceof String) {
                             List<String> list = new ArrayList<String>();
                             list.add(String.valueOf(value));

--- a/rules/src/main/java/org/switchyard/component/rules/exchange/RulesExchangeHandler.java
+++ b/rules/src/main/java/org/switchyard/component/rules/exchange/RulesExchangeHandler.java
@@ -34,6 +34,7 @@ import org.switchyard.Exchange;
 import org.switchyard.ExchangePattern;
 import org.switchyard.HandlerException;
 import org.switchyard.Message;
+import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
 import org.switchyard.common.lang.Strings;
 import org.switchyard.common.type.Classes;
@@ -178,7 +179,7 @@ public class RulesExchangeHandler extends KnowledgeExchangeHandler<RulesComponen
     */
 
     private boolean isDispose(Exchange exchange) {
-        return isBoolean(exchange, RulesConstants.DISPOSE_PROPERTY);
+        return isBoolean(exchange, RulesConstants.DISPOSE_PROPERTY, Scope.IN);
     }
 
     private final class FireUntilHalt implements Runnable, KnowledgeDisposal {

--- a/soap/src/main/java/org/switchyard/component/soap/composer/SOAPComposition.java
+++ b/soap/src/main/java/org/switchyard/component/soap/composer/SOAPComposition.java
@@ -34,14 +34,8 @@ import org.switchyard.component.soap.config.model.SOAPMessageComposerModel;
  */
 public final class SOAPComposition {
 
-    /** The "soap_message_header" context property label. */
-    public static final String SOAP_MESSAGE_HEADER = "soap_message_header";
-
-    /** The "soap_message_mime_header" context property label. */
-    public static final String SOAP_MESSAGE_MIME_HEADER = "soap_message_mime_header";
-
-    /** The SOAP Fault details. */
-    public static final String SOAP_FAULT_INFO = "fault_info";
+    /** The soap_fault_info property name. */
+    public static final String SOAP_FAULT_INFO = "soap_fault_info";
 
     /**
      * Uses the {@link Composition} class to create a SOAP-specific MessageComposer.

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPContextMapperTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPContextMapperTest.java
@@ -27,6 +27,7 @@ import javax.xml.ws.soap.SOAPBinding;
 import org.junit.Assert;
 import org.junit.Test;
 import org.switchyard.Context;
+import org.switchyard.Scope;
 import org.switchyard.component.soap.composer.SOAPBindingData;
 import org.switchyard.component.soap.composer.SOAPContextMapper;
 import org.switchyard.component.soap.composer.SOAPHeadersType;
@@ -53,13 +54,25 @@ public class SOAPContextMapperTest {
         return source;
     }
 
+    private Context newSourceContext() {
+        Context source = new DefaultContext();
+        source.setProperty(FIRST_NAME.toString(), "John", Scope.OUT);
+        source.setProperty(LAST_NAME.toString(), "Doe", Scope.OUT);
+        return source;
+    }
+
     private SOAPMessage newTargetMessage() throws Exception {
         SOAPMessage target = SOAPUtil.createMessage(SOAPBinding.SOAP11HTTP_BINDING);
         return target;
     }
 
+    private Context newTargetContext() {
+        return new DefaultContext();
+    }
+
     private Object getPropertyValue(Context context, QName qname) {
-        return context.getPropertyValue(qname.toString());
+        Object o = context.getProperty(qname.toString(), Scope.IN).getValue();
+        return o;
     }
 
     private Element getChildElement(SOAPMessage message, QName qname) throws Exception {
@@ -87,68 +100,72 @@ public class SOAPContextMapperTest {
     private void testStringContextMapping(SOAPHeadersType soapHeadersType) throws Exception {
         SOAPContextMapper mapper = new SOAPContextMapper();
         mapper.setSOAPHeadersType(soapHeadersType);
-        Context context = new DefaultContext();
         // test mapFrom
-        SOAPMessage source = newSourceMessage();
-        mapper.mapFrom(new SOAPBindingData(source), context);
-        Assert.assertEquals("John", getPropertyValue(context, FIRST_NAME));
-        Assert.assertEquals("Doe", getPropertyValue(context, LAST_NAME));
+        SOAPMessage sourceMessage = newSourceMessage();
+        Context targetContext = newTargetContext();
+        mapper.mapFrom(new SOAPBindingData(sourceMessage), targetContext);
+        Assert.assertEquals("John", getPropertyValue(targetContext, FIRST_NAME));
+        Assert.assertEquals("Doe", getPropertyValue(targetContext, LAST_NAME));
         // test mapTo
-        SOAPMessage target = newTargetMessage();
-        mapper.mapTo(context, new SOAPBindingData(target));
-        Assert.assertEquals("John", getChildElement(target, FIRST_NAME).getTextContent());
-        Assert.assertEquals("Doe", getChildElement(target, LAST_NAME).getTextContent());
+        Context sourceContext = newSourceContext();
+        SOAPMessage targetMessage = newTargetMessage();
+        mapper.mapTo(sourceContext, new SOAPBindingData(targetMessage));
+        Assert.assertEquals("John", getChildElement(targetMessage, FIRST_NAME).getTextContent());
+        Assert.assertEquals("Doe", getChildElement(targetMessage, LAST_NAME).getTextContent());
     }
 
     @Test
     public void testXmlContextMapping() throws Exception {
         SOAPContextMapper mapper = new SOAPContextMapper();
         mapper.setSOAPHeadersType(SOAPHeadersType.XML);
-        Context context = new DefaultContext();
         // test mapFrom
-        SOAPMessage source = newSourceMessage();
-        mapper.mapFrom(new SOAPBindingData(source), context);
-        Assert.assertEquals("<first xmlns=\"urn:names:1.0\">John</first>", getPropertyValue(context, FIRST_NAME));
-        Assert.assertEquals("<last xmlns=\"urn:names:1.0\">Doe</last>", getPropertyValue(context, LAST_NAME));
+        SOAPMessage sourceMessage = newSourceMessage();
+        Context targetContext = newTargetContext();
+        mapper.mapFrom(new SOAPBindingData(sourceMessage), targetContext);
+        Assert.assertEquals("<first xmlns=\"urn:names:1.0\">John</first>", getPropertyValue(targetContext, FIRST_NAME));
+        Assert.assertEquals("<last xmlns=\"urn:names:1.0\">Doe</last>", getPropertyValue(targetContext, LAST_NAME));
         // test mapTo
-        SOAPMessage target = newTargetMessage();
-        mapper.mapTo(context, new SOAPBindingData(target));
-        Assert.assertEquals("John", getChildElement(target, FIRST_NAME).getTextContent());
-        Assert.assertEquals("Doe", getChildElement(target, LAST_NAME).getTextContent());
+        Context sourceContext = newSourceContext();
+        SOAPMessage targetMessage = newTargetMessage();
+        mapper.mapTo(sourceContext, new SOAPBindingData(targetMessage));
+        Assert.assertEquals("John", getChildElement(targetMessage, FIRST_NAME).getTextContent());
+        Assert.assertEquals("Doe", getChildElement(targetMessage, LAST_NAME).getTextContent());
     }
 
     @Test
     public void testConfigContextMapping() throws Exception {
         SOAPContextMapper mapper = new SOAPContextMapper();
         mapper.setSOAPHeadersType(SOAPHeadersType.CONFIG);
-        Context context = new DefaultContext();
         // test mapFrom
-        SOAPMessage source = newSourceMessage();
-        mapper.mapFrom(new SOAPBindingData(source), context);
-        Assert.assertEquals(newConfiguration("<first xmlns=\"urn:names:1.0\">John</first>"), getPropertyValue(context, FIRST_NAME));
-        Assert.assertEquals(newConfiguration("<last xmlns=\"urn:names:1.0\">Doe</last>"), getPropertyValue(context, LAST_NAME));
+        SOAPMessage sourceMessage = newSourceMessage();
+        Context targetContext = newTargetContext();
+        mapper.mapFrom(new SOAPBindingData(sourceMessage), targetContext);
+        Assert.assertEquals(newConfiguration("<first xmlns=\"urn:names:1.0\">John</first>"), getPropertyValue(targetContext, FIRST_NAME));
+        Assert.assertEquals(newConfiguration("<last xmlns=\"urn:names:1.0\">Doe</last>"), getPropertyValue(targetContext, LAST_NAME));
         // test mapTo
-        SOAPMessage target = newTargetMessage();
-        mapper.mapTo(context, new SOAPBindingData(target));
-        Assert.assertEquals("John", getChildElement(target, FIRST_NAME).getTextContent());
-        Assert.assertEquals("Doe", getChildElement(target, LAST_NAME).getTextContent());
+        Context sourceContext = newSourceContext();
+        SOAPMessage targetMessage = newTargetMessage();
+        mapper.mapTo(sourceContext, new SOAPBindingData(targetMessage));
+        Assert.assertEquals("John", getChildElement(targetMessage, FIRST_NAME).getTextContent());
+        Assert.assertEquals("Doe", getChildElement(targetMessage, LAST_NAME).getTextContent());
     }
 
     @Test
     public void testDomContextMapping() throws Exception {
         SOAPContextMapper mapper = new SOAPContextMapper();
         mapper.setSOAPHeadersType(SOAPHeadersType.DOM);
-        Context context = new DefaultContext();
         // test mapFrom
-        SOAPMessage source = newSourceMessage();
-        mapper.mapFrom(new SOAPBindingData(source), context);
-        Assert.assertEquals("<first xmlns=\"urn:names:1.0\">John</first>", toString((Element)getPropertyValue(context, FIRST_NAME)));
-        Assert.assertEquals("<last xmlns=\"urn:names:1.0\">Doe</last>", toString((Element)getPropertyValue(context, LAST_NAME)));
+        SOAPMessage sourceMessage = newSourceMessage();
+        Context targetContext = newTargetContext();
+        mapper.mapFrom(new SOAPBindingData(sourceMessage), targetContext);
+        Assert.assertEquals("<first xmlns=\"urn:names:1.0\">John</first>", toString((Element)getPropertyValue(targetContext, FIRST_NAME)));
+        Assert.assertEquals("<last xmlns=\"urn:names:1.0\">Doe</last>", toString((Element)getPropertyValue(targetContext, LAST_NAME)));
         // test mapTo
-        SOAPMessage target = newTargetMessage();
-        mapper.mapTo(context, new SOAPBindingData(target));
-        Assert.assertEquals("John", getChildElement(target, FIRST_NAME).getTextContent());
-        Assert.assertEquals("Doe", getChildElement(target, LAST_NAME).getTextContent());
+        Context sourceContext = newSourceContext();
+        SOAPMessage targetMesssage = newTargetMessage();
+        mapper.mapTo(sourceContext, new SOAPBindingData(targetMesssage));
+        Assert.assertEquals("John", getChildElement(targetMesssage, FIRST_NAME).getTextContent());
+        Assert.assertEquals("Doe", getChildElement(targetMesssage, LAST_NAME).getTextContent());
     }
 
 }

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPGatewayTest.java
@@ -53,7 +53,7 @@ import org.switchyard.Message;
 import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
 import org.switchyard.common.net.SocketAddr;
-import org.switchyard.component.soap.composer.SOAPFaultInfo;
+import org.switchyard.component.soap.composer.SOAPComposition;
 import org.switchyard.component.soap.config.model.SOAPBindingModel;
 import org.switchyard.component.soap.util.SOAPUtil;
 import org.switchyard.config.model.ModelPuller;
@@ -367,7 +367,7 @@ public class SOAPGatewayTest {
         Message requestMsg = ex.createMessage().setContent(input);
         ex.send(requestMsg);
         handler.waitForFaultMessage();
-        Object faultInfo = ctx.getProperty("fault_info", Scope.IN).getValue();
+        Object faultInfo = ctx.getProperty(SOAPComposition.SOAP_FAULT_INFO, Scope.IN).getValue();
         Assert.assertNotNull(faultInfo);
         Assert.assertEquals(faultStr, faultInfo.toString());
     }


### PR DESCRIPTION
SWITCHYARD-1345: Context properties not scoped or labeled properly in ContextMappers
https://issues.jboss.org/browse/SWITCHYARD-1345
