### PR TITLE
SWITCHYARD-1355 Camel Component do not keep operation name.

### DIFF
--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -122,7 +122,7 @@ public class SwitchYardProducer extends DefaultProducer {
     private String getOperationName(org.apache.camel.Exchange exchange) {
         OperationSelector<CamelBindingData> selector = exchange.getIn().getHeader(CamelConstants.OPERATION_SELETOR_HEADER, OperationSelector.class);
         if (selector == null) {
-            return _operationName;
+            return _operationName == null ? exchange.getIn().getHeader(Exchange.OPERATION_NAME, String.class) : _operationName;
         }
         try {
             return selector.selectOperation(new CamelBindingData(exchange.getIn())).getLocalPart();
@@ -160,11 +160,7 @@ public class SwitchYardProducer extends DefaultProducer {
     }
 
     private String lookupOperationNameFor(final org.apache.camel.Exchange camelExchange, final ServiceReference serviceRef) {
-        // TODO: make this a factory
-        // For CXFRS exchanges
-        String operationName = (String) camelExchange.getIn().getHeader("operationName");
-
-        operationName = getOperationName(camelExchange);
+        String operationName = getOperationName(camelExchange);
 
         // From Service Interface
         if (operationName == null) {

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel.deploy;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.camel.component.mock.MockEndpoint;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.Exchange;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.component.camel.common.CamelConstants;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+
+/**
+ * Test header presence populated by CamelMessageComposer in camel messages.
+ * 
+ * @author Lukasz Dywicki
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(config = "switchyard-activator-proxy-test.xml", mixins = CDIMixIn.class)
+public class CamelProxyTest {
+
+    private final static String MATH_SERVICE = "CamelMathService";
+
+    private SwitchYardCamelContext _camelContext;
+
+    @ServiceOperation(MATH_SERVICE)
+    private Invoker invoker;
+
+    @Before
+    public void verifyContext() {
+        assertNotNull(_camelContext.getWritebleRegistry().get(CamelConstants.SERVICE_DOMAIN));
+    }
+
+    @Test
+    public void shouldInvokeDifferentOperations() throws Exception {
+        MockEndpoint all = _camelContext.getEndpoint("mock:all", MockEndpoint.class);
+        all.expectedBodiesReceived(100.0, 101.0, 11.0);
+
+        all.message(0).header(Exchange.OPERATION_NAME).isEqualTo("abs");
+        all.message(1).header(Exchange.OPERATION_NAME).isEqualTo("cos");
+        all.message(2).header(Exchange.OPERATION_NAME).isEqualTo("pow");
+
+        invoker.operation("abs").sendInOut(100.0);
+        invoker.operation("cos").sendInOut(101.0);
+        invoker.operation("pow").sendInOut(11.0);
+
+        all.assertIsSatisfied();
+    }
+
+}

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/MathService.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/support/MathService.java
@@ -27,8 +27,8 @@ package org.switchyard.component.camel.deploy.support;
  */
 public interface MathService {
 
-    double abs(double value);
-    double cos(double value);
-    double pow(double value) throws IllegalArgumentException;
+    double abs(Double value);
+    double cos(Double value);
+    double pow(Double value) throws IllegalArgumentException;
 
 }

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-proxy-test.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-activator-proxy-test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+    xmlns:camel="urn:switchyard-component-camel:config:1.0"
+    xmlns:core="urn:switchyard-component-camel-core:config:1.0">
+
+    <sca:composite name="MathComposite" targetNamespace="urn:camel-core:test:1.0">
+        <sca:service name="CamelMathService" promote="MathComponent/CamelMathService">
+            <sca:interface.java interface="org.switchyard.component.camel.deploy.support.MathService"/>
+            <core:binding.direct>
+                <core:name>input</core:name>
+            </core:binding.direct>
+        </sca:service>
+
+        <sca:component name="MathComponent">
+            <camel:implementation.camel>
+                <route xmlns="http://camel.apache.org/schema/spring" id="CamelMathRoute">
+                    <to uri="switchyard://MathAll" />
+                </route>
+            </camel:implementation.camel>
+
+            <sca:service name="CamelMathService">
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.MathService"/>
+            </sca:service>
+
+            <sca:reference name="MathAll">
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.MathService"/>
+            </sca:reference>
+        </sca:component>
+
+        <sca:reference name="MathAll" multiplicity="0..1" promote="">
+            <sca:interface.java interface="org.switchyard.component.camel.deploy.support.MathService"/>
+            <core:binding.mock>
+                <core:name>all</core:name>
+            </core:binding.mock>
+        </sca:reference>
+    </sca:composite>
+
+</switchyard>


### PR DESCRIPTION
Fallback check for message operation name header in Camel message.
