### PR TITLE
SWITCHYARD-1387 Can not use jta transaction manager on references only

### DIFF
--- a/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OutboundHandler.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OutboundHandler.java
@@ -31,6 +31,7 @@ import org.switchyard.ExchangePattern;
 import org.switchyard.HandlerException;
 import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.component.camel.common.composer.CamelBindingData;
+import org.switchyard.component.camel.common.transaction.TransactionHelper;
 import org.switchyard.component.common.composer.MessageComposer;
 import org.switchyard.deploy.BaseServiceHandler;
 import org.switchyard.exception.SwitchYardException;
@@ -85,6 +86,8 @@ public class OutboundHandler extends BaseServiceHandler {
         _camelContext = context;
         _messageComposer = messageComposer;
         _producerTemplate = producerTemplate == null ? _camelContext.createProducerTemplate() : producerTemplate;
+
+        TransactionHelper.useTransactionManager(_uri, context);
     }
 
     /**

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/transaction/TransactionHelper.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/transaction/TransactionHelper.java
@@ -1,0 +1,113 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.transaction;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.apache.camel.util.URISupport;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.component.camel.common.CamelConstants;
+import org.switchyard.exception.SwitchYardException;
+
+/**
+ * Utility class which encapsulates logic related to operations needed to register
+ * Spring {@link PlatformTransactionManager} and transaction policy beans necessary
+ * in camel routes.
+ */
+public final class TransactionHelper {
+
+    private final SwitchYardCamelContext _context;
+
+    /**
+     * Private constructor seen only from static method.
+     * 
+     * @param context Camel context instance.
+     */
+    private TransactionHelper(SwitchYardCamelContext context) {
+        this._context = context;
+    }
+
+    private boolean isDefaultJtaTransactionName(final String tmName) {
+        return tmName.equals(TransactionManagerFactory.TM);
+    }
+
+    private boolean isRegisteredInCamelRegistry(String beanName) {
+        return _context.getRegistry().lookup(beanName) != null;
+    }
+
+    private void addToCamelRegistry() {
+        final PlatformTransactionManager transactionManager = TransactionManagerFactory.getInstance().create();
+        // Add the transaction manager
+        _context.getWritebleRegistry().put(TransactionManagerFactory.TM, transactionManager);
+        // Add a policy ref bean pointing to the transaction manager
+        _context.getWritebleRegistry().put(CamelConstants.TRANSACTED_REF, new SpringTransactionPolicy(transactionManager));
+    }
+
+    private String getTransactionManagerName(URI uri) {
+        try {
+            final Map<String, Object> parseParameters = URISupport.parseParameters(uri);
+            String name = (String) parseParameters.get("transactionManager");
+            if (name != null) {
+                name = name.replace("#", "");
+            }
+            return name;
+        } catch (URISyntaxException e) {
+            throw new SwitchYardException(e);
+        }
+    }
+
+    private boolean process(URI endpointUri) {
+        String transactionManagerName = getTransactionManagerName(endpointUri);
+        if (transactionManagerName == null) {
+            return false;
+        }
+        if (!isRegisteredInCamelRegistry(transactionManagerName) && isDefaultJtaTransactionName(transactionManagerName)) {
+            addToCamelRegistry();
+        }
+        return true;
+    }
+
+    /**
+     * Process component uri and register default transaction manager when necessary.
+     * 
+     * @param endpointUri Camel endpoint uri.
+     * @param context Camel context instance.
+     * @return True if transaction manager is necessary for endpoint.
+     */
+    public static boolean useTransactionManager(URI endpointUri, SwitchYardCamelContext context) {
+        return new TransactionHelper(context).process(endpointUri);
+    }
+
+    /**
+     * Process component uri and register default transaction manager when necessary.
+     * 
+     * @param endpointUri String with endpoint uri.
+     * @param context Camel context instance.
+     * @return True if transaction manager is necessary for endpoint.
+     */
+    public static boolean useTransactionManager(String endpointUri, SwitchYardCamelContext context) {
+        return useTransactionManager(URI.create(endpointUri), context);
+    }
+
+
+}

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTest.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTest.java
@@ -20,8 +20,9 @@
  */
 package org.switchyard.component.camel.common.handler;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
@@ -103,14 +104,10 @@ public class InboundHandlerTest extends InboundHandlerTestBase {
 
     @Test
     public void hasTransactionManagerConfigured() {
-        mockTransaction("jtaTransactionMgr");
-        mockTransaction("jtaTransactionManager");
-        InboundHandler<?> handler = createInboundHandler("jms://queue?transactionManager=%23jtaTransactionMgr");
-        String transactedRef = handler.getTransactionManagerName();
-        assertThat(transactedRef, is(equalTo("jtaTransactionMgr")));
-        handler = createInboundHandler("jms://GreetingServiceQueue?connectionFactory=%23&JmsXA&transactionManager=%23jtaTransactionManager");
-        transactedRef = handler.getTransactionManagerName();
-        assertThat(transactedRef, is(equalTo("jtaTransactionManager")));
+        createInboundHandler("jms://queue?transactionManager=%23jtaTransactionMgr");
+        assertThat(_camelContext.getRegistry().lookup("jtaTransactionMgr"), is(nullValue()));
+        createInboundHandler("jms://GreetingServiceQueue?connectionFactory=%23&JmsXA&transactionManager=%23jtaTransactionManager");
+        assertThat(_camelContext.getRegistry().lookup("jtaTransactionManager"), is(notNullValue()));
     }
 
     /**

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTestBase.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/InboundHandlerTestBase.java
@@ -22,16 +22,23 @@ import static org.mockito.Mockito.mock;
 
 import java.net.URI;
 
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
 import javax.xml.namespace.QName;
 
 import org.apache.camel.component.mock.MockComponent;
 import org.apache.camel.spring.spi.SpringTransactionPolicy;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.mockito.Mockito;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.model.v1.V1BaseCamelBindingModel;
+import org.switchyard.component.camel.common.transaction.TransactionManagerFactory;
+import org.switchyard.component.test.mixins.naming.NamingMixIn;
 import org.switchyard.config.Configuration;
 import org.switchyard.config.model.Descriptor;
 import org.switchyard.config.model.composer.ContextMapperModel;
@@ -48,6 +55,8 @@ import org.switchyard.config.model.selector.OperationSelectorModel;
  * mapper are place in camel-switchyard module.
  */
 public abstract class InboundHandlerTestBase {
+
+    private static NamingMixIn mixIn = new NamingMixIn();
 
     protected SwitchYardCamelContext _camelContext;
     protected Configuration _configuration;
@@ -103,4 +112,18 @@ public abstract class InboundHandlerTestBase {
         _camelContext.getWritebleRegistry().put(manager, transactionManager);
         _camelContext.getWritebleRegistry().put(CamelConstants.TRANSACTED_REF, new SpringTransactionPolicy(transactionManager));
     }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        mixIn.initialize();
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_USER_TRANSACTION, mock(UserTransaction.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_MANANGER, mock(TransactionManager.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_SYNC_REG, mock(TransactionSynchronizationRegistry.class));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        mixIn.uninitialize();
+    }
+
 }

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/handler/OutboundHandlerTest.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/handler/OutboundHandlerTest.java
@@ -23,11 +23,16 @@ package org.switchyard.component.camel.common.handler;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+import javax.transaction.UserTransaction;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.EndpointInject;
@@ -48,8 +53,10 @@ import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.component.camel.common.composer.CamelBindingData;
 import org.switchyard.component.camel.common.composer.CamelComposition;
 import org.switchyard.component.camel.common.model.CamelBindingModel;
+import org.switchyard.component.camel.common.transaction.TransactionManagerFactory;
 import org.switchyard.component.common.composer.MessageComposer;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.component.test.mixins.naming.NamingMixIn;
 import org.switchyard.metadata.InOnlyService;
 import org.switchyard.metadata.ServiceInterface;
 import org.switchyard.test.Invoker;
@@ -66,6 +73,8 @@ import org.switchyard.test.SwitchYardTestCaseConfig;
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
 public class OutboundHandlerTest extends CamelTestSupport {
+
+    private NamingMixIn _mixIn;
 
     @EndpointInject(uri = "mock:result")
     private static MockEndpoint camelEndpoint;
@@ -109,6 +118,34 @@ public class OutboundHandlerTest extends CamelTestSupport {
         assertThat(camelEndpoint.getReceivedCounter(), is(1));
         final String received = (String) camelEndpoint.getReceivedExchanges().get(0).getIn().getBody();
         assertThat(received, is(equalTo(payload)));
+    }
+
+    @Test
+    public void checkTransactionManagerRegistration() throws Exception {
+        _mixIn.initialize();
+        _mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_USER_TRANSACTION, mock(UserTransaction.class));
+        _mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_MANANGER, mock(TransactionManager.class));
+        _mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_SYNC_REG, mock(TransactionSynchronizationRegistry.class));
+
+        bindingModel = mock(CamelBindingModel.class);
+        when(bindingModel.getComponentURI()).thenReturn(URI.create("transaction:foo?transactionManager=%23jtaTransactionManager"));
+        _messageComposer = CamelComposition.getMessageComposer();
+        _serviceDomain.registerService(_targetService.getServiceName(),
+            new InOnlyService(), 
+            new OutboundHandler(bindingModel.getComponentURI().toString(),
+                (SwitchYardCamelContext) context, _messageComposer
+            )
+        );
+        _service = _serviceDomain.registerServiceReference(
+            _targetService.getServiceName(), new InOnlyService());
+        Exchange exchange = _service.createExchange();
+
+        MockEndpoint endpoint = getMockEndpoint("mock:result");
+        endpoint.expectedBodiesReceived("foo");
+        exchange.send(exchange.createMessage().setContent("foo"));
+    
+        assertThat(context.getRegistry().lookup(TransactionManagerFactory.TM), is(notNullValue()));
+        _mixIn.uninitialize();
     }
 
     @Test
@@ -168,9 +205,7 @@ public class OutboundHandlerTest extends CamelTestSupport {
 
     @Override
     protected CamelContext createCamelContext() throws Exception {
-        SwitchYardCamelContext camelContext = new SwitchYardCamelContext();
-        camelContext.setRegistry(createRegistry());
-        return camelContext;
+        return new SwitchYardCamelContext();
     }
 
     @Override
@@ -181,7 +216,9 @@ public class OutboundHandlerTest extends CamelTestSupport {
                 .convertBodyTo(String.class)
                 .log("Before Routing to mock:result body: ${body}")
                 .to("mock:result");
+                from("transaction:foo").to("mock:result");
             }
         };
     }
+
 }

--- a/common/camel/src/test/java/org/switchyard/component/camel/common/transaction/TransactionManagerFactoryTest.java
+++ b/common/camel/src/test/java/org/switchyard/component/camel/common/transaction/TransactionManagerFactoryTest.java
@@ -66,9 +66,9 @@ public class TransactionManagerFactoryTest {
 
     @Test
     public void createSpringTransactionManager() throws Exception {
-        mixIn.getInitialContext().bind("java:comp/UserTransaction", mock(UserTransaction.class));
-        mixIn.getInitialContext().bind("java:comp/TransactionManager", mock(TransactionManager.class));
-        mixIn.getInitialContext().bind("java:comp/TransactionSynchronizationRegistry", mock(TransactionSynchronizationRegistry.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_USER_TRANSACTION, mock(UserTransaction.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_MANANGER, mock(TransactionManager.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_SYNC_REG, mock(TransactionSynchronizationRegistry.class));
         final TransactionManagerFactory factory = TransactionManagerFactory.getInstance();
         final PlatformTransactionManager tm = factory.create();
         assertThat(tm, is(notNullValue()));
@@ -82,9 +82,9 @@ public class TransactionManagerFactoryTest {
 
     @Test
     public void createJBossTransactionManager() throws Exception {
-        mixIn.getInitialContext().bind("java:jboss/UserTransaction", mock(UserTransaction.class));
-        mixIn.getInitialContext().bind("java:jboss/TransactionManager", mock(TransactionManager.class));
-        mixIn.getInitialContext().bind("java:jboss/TransactionSynchronizationRegistry", mock(TransactionSynchronizationRegistry.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_USER_TRANSACTION, mock(UserTransaction.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_MANANGER, mock(TransactionManager.class));
+        mixIn.getInitialContext().bind(TransactionManagerFactory.JBOSS_TRANSACTION_SYNC_REG, mock(TransactionSynchronizationRegistry.class));
         final TransactionManagerFactory factory = TransactionManagerFactory.getInstance();
         final PlatformTransactionManager tm = factory.create();
         assertThat(tm, is(instanceOf(JtaTransactionManager.class)));


### PR DESCRIPTION
Fix which ensures that JtaTransactionManager is getting registered for OutboundHandler instances too.
