### PR TITLE
SWITCHYARD-1402 Remove CamelMessageComposer from implementation.camel.

### DIFF
--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardConsumer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardConsumer.java
@@ -20,17 +20,28 @@
  */
 package org.switchyard.component.camel;
 
+import static org.switchyard.Exchange.FAULT_TYPE;
+import static org.switchyard.Exchange.OPERATION_NAME;
+import static org.switchyard.Exchange.SERVICE_NAME;
+
+import javax.activation.DataHandler;
+
 import org.apache.camel.Endpoint;
 import org.apache.camel.Processor;
 import org.apache.camel.impl.DefaultConsumer;
+import org.apache.camel.impl.DefaultMessage;
 import org.switchyard.Exchange;
 import org.switchyard.ExchangePattern;
 import org.switchyard.HandlerException;
-import org.switchyard.Message;
-import org.switchyard.component.camel.common.composer.CamelBindingData;
-import org.switchyard.component.common.composer.MessageComposer;
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.common.camel.ContextPropertyUtil;
+import org.switchyard.common.camel.HandlerDataSource;
+import org.switchyard.common.camel.SwitchYardMessage;
 import org.switchyard.deploy.ServiceHandler;
 import org.switchyard.exception.SwitchYardException;
+import org.switchyard.label.BehaviorLabel;
+import org.switchyard.metadata.ServiceOperation;
 
 /**
  * A SwitchYardConsumer is both a Camel Consumer and an SwitchYard ExchangeHandler.
@@ -42,23 +53,44 @@ import org.switchyard.exception.SwitchYardException;
  */
 public class SwitchYardConsumer extends DefaultConsumer implements ServiceHandler {
 
-    private final MessageComposer<CamelBindingData> _messageComposer;
-
     /**
      * Sole constructor.
      * 
      * @param endpoint The Camel endpoint that this consumer was created by.
      * @param processor The Camel processor that this consumer will delegate to.
-     * @param messageComposer the MessageComposer this consumer should use
      */
-    public SwitchYardConsumer(final Endpoint endpoint, final Processor processor, final MessageComposer<CamelBindingData> messageComposer) {
+    public SwitchYardConsumer(final Endpoint endpoint, final Processor processor) {
         super(endpoint, processor);
-        _messageComposer = messageComposer;
     }
-    
+
     @Override
     public void handleMessage(final Exchange switchyardExchange) throws HandlerException {
-        final org.apache.camel.Exchange camelExchange = createCamelExchange(switchyardExchange);
+        org.apache.camel.Exchange camelExchange = getEndpoint().createExchange(isInOut(switchyardExchange) ? org.apache.camel.ExchangePattern.InOut : org.apache.camel.ExchangePattern.InOnly);
+        DefaultMessage targetMessage = new SwitchYardMessage();
+        targetMessage.setBody(switchyardExchange.getMessage().getContent());
+
+        for (Property property : switchyardExchange.getContext().getProperties()) {
+            if (property.hasLabel(BehaviorLabel.TRANSIENT.label()) || ContextPropertyUtil.isReservedProperty(property.getName(), property.getScope())) {
+                continue;
+            }
+
+            if (Scope.EXCHANGE.equals(property.getScope())) {
+                camelExchange.setProperty(property.getName(), property.getValue());
+            } else {
+                targetMessage.setHeader(property.getName(), property.getValue());
+            }
+        }
+
+        for (String attachementName : switchyardExchange.getMessage().getAttachmentMap().keySet()) {
+            targetMessage.addAttachment(attachementName, new DataHandler(switchyardExchange.getMessage().getAttachment(attachementName)));
+        }
+
+        ServiceOperation operation = switchyardExchange.getContract().getProviderOperation();
+        targetMessage.setHeader(OPERATION_NAME, operation.getName());
+        targetMessage.setHeader(FAULT_TYPE, operation.getFaultType());
+        targetMessage.setHeader(SERVICE_NAME, switchyardExchange.getProvider().getName());
+        camelExchange.setIn(targetMessage);
+
         invokeCamelProcessor(camelExchange);
 
         handleExceptionsFromCamel(camelExchange);
@@ -101,32 +133,35 @@ public class SwitchYardConsumer extends DefaultConsumer implements ServiceHandle
         }
     }
 
-    private org.apache.camel.Exchange createCamelExchange(final Exchange switchyardExchange) {
-        org.apache.camel.Exchange camelExchange = isInOut(switchyardExchange) 
-                ? getEndpoint().createExchange(org.apache.camel.ExchangePattern.InOut)
-                : getEndpoint().createExchange(org.apache.camel.ExchangePattern.InOnly);
-         try {
-             _messageComposer.decompose(switchyardExchange, new CamelBindingData(camelExchange.getIn()));
-         } catch (Exception e) {
-             throw new SwitchYardException(e);
-         }
-        return camelExchange;
-    }
-
-    private void sendResponse(org.apache.camel.Exchange camelExchange, final Exchange switchyardExchange) {
+    private void sendResponse(org.apache.camel.Exchange camelExchange, final Exchange switchyardExchange) throws HandlerException {
         final org.apache.camel.Message camelMessage;
         if (camelExchange.hasOut()) {
             camelMessage = camelExchange.getOut();
         } else {
             camelMessage = camelExchange.getIn();
         }
-        Message switchyardMessage;
-        try {
-            switchyardMessage = _messageComposer.compose(new CamelBindingData(camelMessage), switchyardExchange, true);
-        } catch (Exception e) {
-            throw new SwitchYardException(e);
+
+        org.switchyard.Message message = switchyardExchange.createMessage();
+        message.setContent(camelMessage.getBody());
+
+        for (String property : camelExchange.getProperties().keySet()) {
+            if (ContextPropertyUtil.isReservedProperty(property, Scope.EXCHANGE)) {
+                continue;
+            }
+            message.getContext().setProperty(property, camelExchange.getProperty(property), Scope.EXCHANGE);
         }
-        switchyardExchange.send(switchyardMessage);
+        for (String header : camelMessage.getHeaders().keySet()) {
+            if (ContextPropertyUtil.isReservedProperty(header, Scope.MESSAGE)) {
+                continue;
+            }
+            message.getContext().setProperty(header, camelMessage.getHeader(header), Scope.MESSAGE);
+        }
+
+        for (String attachementName : camelMessage.getAttachmentNames()) {
+            message.addAttachment(attachementName, new HandlerDataSource(camelMessage.getAttachment(attachementName)));
+        }
+
+        switchyardExchange.send(message);
     }
 
     private boolean isInOut(final Exchange exchange) {

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardEndpoint.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardEndpoint.java
@@ -98,7 +98,7 @@ public class SwitchYardEndpoint extends DefaultEndpoint {
      */
     @Override
     public Consumer createConsumer(final Processor processor) throws Exception {
-        _consumer = new SwitchYardConsumer(this, processor, getMessageComposer());
+        _consumer = new SwitchYardConsumer(this, processor);
         return _consumer;
     }
 

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -31,6 +31,7 @@ import org.switchyard.Exchange;
 import org.switchyard.Message;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
+import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.BindingDataCreator;
 import org.switchyard.component.camel.common.composer.BindingDataCreatorResolver;
@@ -82,8 +83,8 @@ public class SwitchYardProducer extends DefaultProducer {
 
     @Override
     public void process(final org.apache.camel.Exchange camelExchange) throws Exception {
-        final String targetUri = (String) camelExchange.getProperty(org.apache.camel.Exchange.TO_ENDPOINT);
-        ServiceDomain domain = (ServiceDomain) camelExchange.getContext().getRegistry().lookup(CamelConstants.SERVICE_DOMAIN);
+        final String targetUri = camelExchange.getProperty(org.apache.camel.Exchange.TO_ENDPOINT, String.class);
+        ServiceDomain domain = ((SwitchYardCamelContext) camelExchange.getContext()).getServiceDomain();
 
         final ServiceReference serviceRef = lookupServiceReference(targetUri, domain);
         MessageComposer<CamelBindingData> composer = getMessageComposer(camelExchange);
@@ -103,7 +104,7 @@ public class SwitchYardProducer extends DefaultProducer {
             SecurityContext.get(switchyardExchange).getCredentials().addAll(
                 ((SecurityBindingData) bindingData).extractCredentials());
         }
-        Message switchyardMessage = composer.compose(bindingData, switchyardExchange, true);
+        Message switchyardMessage = composer.compose(bindingData, switchyardExchange);
         switchyardExchange.send(switchyardMessage);
     }
 

--- a/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTestBase.java
+++ b/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTestBase.java
@@ -36,7 +36,7 @@ public abstract class SwitchYardComponentTestBase extends CamelTestSupport {
     @Override
     protected CamelContext createCamelContext() throws Exception {
         _camelContext = new SwitchYardCamelContext(false);
-        _camelContext.getWritebleRegistry().put(CamelConstants.SERVICE_DOMAIN, _serviceDomain);
+        _camelContext.setServiceDomain(_serviceDomain);
         return _camelContext;
     }
 

--- a/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/util/Composer.java
+++ b/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/util/Composer.java
@@ -32,8 +32,8 @@ public class Composer extends CamelMessageComposer {
     public static final String DECOMPOSE_PREFIX = "Composer decompose ";
 
     @Override
-    public Message compose(CamelBindingData source, Exchange exchange, boolean create) throws Exception {
-        Message message = super.compose(source, exchange, create);
+    public Message compose(CamelBindingData source, Exchange exchange) throws Exception {
+        Message message = super.compose(source, exchange);
         message.setContent(COMPOSE_PREFIX + message.getContent(String.class));
         return message;
     }

--- a/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
+++ b/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelActivator.java
@@ -40,7 +40,7 @@ import org.switchyard.component.camel.SwitchYardEndpoint;
 import org.switchyard.component.camel.SwitchYardPropertiesParser;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.CamelComposition;
-import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
+import org.switchyard.component.camel.common.deploy.BaseCamelActivator;
 import org.switchyard.component.camel.model.CamelComponentImplementationModel;
 import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.config.model.composite.ComponentReferenceModel;
@@ -53,7 +53,7 @@ import org.switchyard.exception.SwitchYardException;
  * 
  * @author Daniel Bevenius
  */
-public class CamelActivator extends BaseBindingActivator {
+public class CamelActivator extends BaseCamelActivator {
 
     /**
      * Creates a new activator for Camel endpoint types.
@@ -61,7 +61,7 @@ public class CamelActivator extends BaseBindingActivator {
      * @param context Camel context to use.
      * @param types Activation types.
      */
-    public CamelActivator(SwitchYardCamelContext context, String[] types) {
+    public CamelActivator(SwitchYardCamelContext context, String ... types) {
         super(context, types);
     }
 
@@ -83,6 +83,11 @@ public class CamelActivator extends BaseBindingActivator {
         }
 
         return handler;
+    }
+
+    @Override
+    public void deactivateService(QName name, ServiceHandler handler) {
+        // nothing to do here ...
     }
 
     private ServiceHandler handleImplementation(final ComponentServiceModel config, final QName serviceName) {

--- a/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelComponent.java
+++ b/camel/component/src/main/java/org/switchyard/component/camel/deploy/CamelComponent.java
@@ -19,8 +19,7 @@
 package org.switchyard.component.camel.deploy;
 
 import org.switchyard.common.camel.SwitchYardCamelContext;
-import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
-import org.switchyard.component.camel.common.deploy.BaseBindingComponent;
+import org.switchyard.component.camel.common.deploy.BaseCamelComponent;
 import org.switchyard.component.camel.model.v1.V1CamelImplementationModel;
 
 /**
@@ -28,7 +27,7 @@ import org.switchyard.component.camel.model.v1.V1CamelImplementationModel;
  *
  * @author Magesh Kumar B <mageshbk@jboss.com> (C) 2011 Red Hat Inc.
  */
-public class CamelComponent extends BaseBindingComponent {
+public class CamelComponent extends BaseCamelComponent {
 
     /**
      * Default constructor.
@@ -38,7 +37,7 @@ public class CamelComponent extends BaseBindingComponent {
     }
 
     @Override
-    protected BaseBindingActivator createActivator(SwitchYardCamelContext context, String... types) {
+    protected CamelActivator createActivator(SwitchYardCamelContext context, String... types) {
         return new CamelActivator(context, types);
     }
 

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelMathTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelMathTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.Exchange;
 import org.switchyard.common.camel.SwitchYardCamelContext;
-import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.test.Invoker;
 import org.switchyard.test.ServiceOperation;
@@ -59,7 +58,7 @@ public class CamelMathTest {
 
     @Before
     public void verifyContext() {
-        assertNotNull(_camelContext.getWritebleRegistry().get(CamelConstants.SERVICE_DOMAIN));
+        assertNotNull(_camelContext.getServiceDomain());
     }
 
     @Test

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.Exchange;
 import org.switchyard.common.camel.SwitchYardCamelContext;
-import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.test.Invoker;
 import org.switchyard.test.ServiceOperation;
@@ -53,7 +52,7 @@ public class CamelProxyTest {
 
     @Before
     public void verifyContext() {
-        assertNotNull(_camelContext.getWritebleRegistry().get(CamelConstants.SERVICE_DOMAIN));
+        assertNotNull(_camelContext.getServiceDomain());
     }
 
     @Test

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/math-route.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/math-route.xml
@@ -32,6 +32,7 @@
                 <to uri="switchyard://MathAbs" />
             </when>
             <otherwise>
+                <log message="Moving ${body} ${in.headers} to unknown" />
                 <to uri="mock:unknown" />
             </otherwise>
         </choice>

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/CamelConstants.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/CamelConstants.java
@@ -31,12 +31,6 @@ public interface CamelConstants {
     String SWITCHYARD_COMPONENT_NAME = "switchyard";
 
     /**
-     * Property added to each Camel Context so that code initialized inside 
-     * Camel can access the SY service domain.
-     */
-    String SERVICE_DOMAIN = "org.switchyard.camel.serviceDomain";
-
-    /**
      * Name of message header where operation selector is stored.
      */
     String OPERATION_SELECTOR_HEADER = "org.switchyard.operationSelector";

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelContextMapper.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelContextMapper.java
@@ -27,6 +27,7 @@ import org.apache.camel.Message;
 import org.switchyard.Context;
 import org.switchyard.Property;
 import org.switchyard.Scope;
+import org.switchyard.common.camel.ContextPropertyUtil;
 import org.switchyard.component.common.composer.BaseRegexContextMapper;
 import org.switchyard.component.common.label.ComponentLabel;
 import org.switchyard.component.common.label.EndpointLabel;
@@ -71,7 +72,7 @@ public class CamelContextMapper extends BaseRegexContextMapper<CamelBindingData>
 
         for (Map.Entry<String,Object> header : message.getHeaders().entrySet()) {
             String name = header.getKey();
-            if (matches(name) && !name.startsWith("org.switchyard.bus.camel")) {
+            if (matches(name) && !ContextPropertyUtil.isReservedProperty(name, Scope.MESSAGE)) {
                 Object value = header.getValue();
                 if (value != null) {
                     context.setProperty(name, value, Scope.MESSAGE).addLabels(getCamelLabels());
@@ -81,7 +82,7 @@ public class CamelContextMapper extends BaseRegexContextMapper<CamelBindingData>
         if (exchange != null) {
             for (Map.Entry<String,Object> property : exchange.getProperties().entrySet()) {
                 String name = property.getKey();
-                if (matches(name) && !name.startsWith("org.switchyard.bus.camel")) {
+                if (matches(name) && !ContextPropertyUtil.isReservedProperty(name, Scope.EXCHANGE)) {
                     Object value = property.getValue();
                     if (value != null) {
                         context.setProperty(name, value, Scope.EXCHANGE).addLabels(getCamelLabels());
@@ -101,7 +102,7 @@ public class CamelContextMapper extends BaseRegexContextMapper<CamelBindingData>
 
         for (Property property : context.getProperties(Scope.MESSAGE)) {
             String name = property.getName();
-            if (matches(name) && !name.startsWith("org.switchyard.bus.camel")) {
+            if (matches(name) && !ContextPropertyUtil.isReservedProperty(name, Scope.MESSAGE)) {
                 Object value = property.getValue();
                 if (value != null) {
                     message.setHeader(name, value);
@@ -111,7 +112,7 @@ public class CamelContextMapper extends BaseRegexContextMapper<CamelBindingData>
         if (exchange != null) {
             for (Property property : context.getProperties(Scope.EXCHANGE)) {
                 String name = property.getName();
-                if (matches(name) && !name.startsWith("org.switchyard.bus.camel")) {
+                if (matches(name) && !ContextPropertyUtil.isReservedProperty(name, Scope.EXCHANGE)) {
                     Object value = property.getValue();
                     if (value != null) {
                         exchange.setProperty(name, value);

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelMessageComposer.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelMessageComposer.java
@@ -50,8 +50,8 @@ public class CamelMessageComposer extends BaseMessageComposer<CamelBindingData> 
      * {@inheritDoc}
      */
     @Override
-    public Message compose(CamelBindingData source, Exchange exchange, boolean create) throws Exception {
-        Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public Message compose(CamelBindingData source, Exchange exchange) throws Exception {
+        Message message = exchange.createMessage();
 
         // map context properties
         getContextMapper().mapFrom(source, exchange.getContext(message));

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseBindingActivator.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseBindingActivator.java
@@ -25,9 +25,7 @@ import org.switchyard.component.camel.common.composer.CamelComposition;
 import org.switchyard.component.camel.common.handler.InboundHandler;
 import org.switchyard.component.camel.common.handler.OutboundHandler;
 import org.switchyard.component.camel.common.model.CamelBindingModel;
-import org.switchyard.config.Configuration;
 import org.switchyard.config.model.composite.BindingModel;
-import org.switchyard.deploy.BaseActivator;
 import org.switchyard.deploy.ServiceHandler;
 
 /**
@@ -35,59 +33,32 @@ import org.switchyard.deploy.ServiceHandler;
  * 
  * @author Lukasz Dywicki
  */
-public class BaseBindingActivator extends BaseActivator {
-
-    private Configuration _environment;
-    private SwitchYardCamelContext _camelContext;
+public class BaseBindingActivator extends BaseCamelActivator {
 
     protected BaseBindingActivator(SwitchYardCamelContext context, String ... types) {
-        super(types);
-        _camelContext = context;
-    }
-
-    /**
-     * Specify environment configuration for binding.
-     * 
-     * @param config Environment settings.
-     */
-    public void setEnvironment(Configuration config) {
-        _environment = config;
+        super(context, types);
     }
 
     @Override
     public ServiceHandler activateBinding(QName serviceName, BindingModel config) {
         CamelBindingModel binding = (CamelBindingModel) config;
-        binding.setEnvironment(_environment);
+        binding.setEnvironment(getEnvironment());
 
         if (binding.isServiceBinding()) {
             return createInboundHandler(serviceName, binding);
         } else {
-            return new OutboundHandler(binding.getComponentURI().toString(), _camelContext, CamelComposition
+            return new OutboundHandler(binding.getComponentURI().toString(), getCamelContext(), CamelComposition
                 .getMessageComposer(binding));
         }
     }
 
     protected <T extends CamelBindingModel> InboundHandler<T> createInboundHandler(QName serviceName, T binding) {
-        return new InboundHandler<T>(binding, _camelContext, serviceName);
+        return new InboundHandler<T>(binding, getCamelContext(), serviceName);
     }
 
     @Override
     public void deactivateBinding(QName name, ServiceHandler handler) {
         // anything to do here?
-    }
-
-    @Override
-    public void deactivateService(QName name, ServiceHandler handler) {
-        // anything to do here?
-    }
-
-    /**
-     * Gets the {@link CamelContext} used by this Activator.
-     * 
-     * @return CamelContext the {@link CamelContext} used by this Activator.
-     */
-    public SwitchYardCamelContext getCamelContext() {
-        return _camelContext;
     }
 
 }

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseBindingComponent.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseBindingComponent.java
@@ -18,18 +18,12 @@
  */
 package org.switchyard.component.camel.common.deploy;
 
-import java.util.List;
-
-import org.switchyard.ServiceDomain;
 import org.switchyard.common.camel.SwitchYardCamelContext;
-import org.switchyard.component.camel.common.CamelConstants;
-import org.switchyard.deploy.Activator;
-import org.switchyard.deploy.BaseComponent;
 
 /**
  * Base class for camel binding components.
  */
-public abstract class BaseBindingComponent extends BaseComponent {
+public abstract class BaseBindingComponent extends BaseCamelComponent {
 
     /**
      * Default constructor.
@@ -38,27 +32,10 @@ public abstract class BaseBindingComponent extends BaseComponent {
      * @param types Names of supported elements.
      */
     protected BaseBindingComponent(String name, String ... types) {
-        super(types);
-        setName(name);
+        super(name, types);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public Activator createActivator(ServiceDomain domain) {
-        List<String> activationTypes = getActivationTypes();
-        String[] types = activationTypes.toArray(new String[activationTypes.size()]);
-
-        SwitchYardCamelContext camelContext = (SwitchYardCamelContext) domain.getProperties()
-            .get(SwitchYardCamelContext.CAMEL_CONTEXT_PROPERTY);
-        camelContext.getWritebleRegistry().put(CamelConstants.SERVICE_DOMAIN, domain);
-        BaseBindingActivator activator = createActivator(camelContext, types);
-        activator.setServiceDomain(domain);
-        activator.setEnvironment(getConfig());
-        return activator;
-    }
-
     protected BaseBindingActivator createActivator(SwitchYardCamelContext context, String ... types) {
         return new BaseBindingActivator(context, types);
     }

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseCamelActivator.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseCamelActivator.java
@@ -1,0 +1,67 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.deploy;
+
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.config.Configuration;
+import org.switchyard.deploy.BaseActivator;
+
+/**
+ * Activator for handling camel bindings on both, service and reference, sides.
+ * 
+ * @author Lukasz Dywicki
+ */
+public class BaseCamelActivator extends BaseActivator {
+
+    private Configuration _environment;
+    private SwitchYardCamelContext _camelContext;
+
+    protected BaseCamelActivator(SwitchYardCamelContext context, String ... types) {
+        super(types);
+        _camelContext = context;
+    }
+
+    /**
+     * Specify environment configuration for binding.
+     * 
+     * @param config Environment settings.
+     */
+    public void setEnvironment(Configuration config) {
+        _environment = config;
+    }
+
+    /**
+     * Gets the {@ling Configuration} used by this Activator.
+     * 
+     * @return Configuration of the Activator.
+     */
+    public Configuration getEnvironment() {
+        return _environment;
+    }
+
+    /**
+     * Gets the {@link SwitchYardCamelContext} used by this Activator.
+     * 
+     * @return The CamelContext used by this Activator.
+     */
+    public SwitchYardCamelContext getCamelContext() {
+        return _camelContext;
+    }
+
+}

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseCamelComponent.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/deploy/BaseCamelComponent.java
@@ -1,0 +1,70 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.common.deploy;
+
+import java.util.List;
+
+import org.switchyard.ServiceDomain;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.deploy.Activator;
+import org.switchyard.deploy.BaseComponent;
+
+/**
+ * Base class for camel binding components.
+ */
+public abstract class BaseCamelComponent extends BaseComponent {
+
+    /**
+     * Default constructor.
+     * 
+     * @param name Component name.
+     * @param types Names of supported elements.
+     */
+    protected BaseCamelComponent(String name, String ... types) {
+        super(types);
+        setName(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Activator createActivator(ServiceDomain domain) {
+        List<String> activationTypes = getActivationTypes();
+        String[] types = activationTypes.toArray(new String[activationTypes.size()]);
+
+        SwitchYardCamelContext camelContext = (SwitchYardCamelContext) domain.getProperties()
+            .get(SwitchYardCamelContext.CAMEL_CONTEXT_PROPERTY);
+        BaseCamelActivator activator = createActivator(camelContext, types);
+        activator.setServiceDomain(domain);
+        activator.setEnvironment(getConfig());
+        return activator;
+    }
+
+    /**
+     * Creates activator for component.
+     * 
+     * @param camelContext Camel context.
+     * @param types Activation types supported by component.
+     * @return Activator instance.
+     */
+    protected abstract BaseCamelActivator createActivator(SwitchYardCamelContext camelContext, String ... types);
+
+}
+

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OutboundHandler.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/handler/OutboundHandler.java
@@ -150,7 +150,7 @@ public class OutboundHandler extends BaseServiceHandler {
         if (camelExchange.getException() != null) {
             throw new HandlerException(camelExchange.getException());
         }
-        return camelExchange.getOut().getBody();
+        return camelExchange.hasOut() ? camelExchange.getOut().getBody() : camelExchange.getIn().getBody();
     }
 
     private void sendResponseToSwitchyard(final Exchange switchyardExchange, final Object payload) {

--- a/common/common/src/main/java/org/switchyard/component/common/composer/MessageComposer.java
+++ b/common/common/src/main/java/org/switchyard/component/common/composer/MessageComposer.java
@@ -47,11 +47,10 @@ public interface MessageComposer<D extends BindingData> {
      * Takes the data from the passed in source object and composes a SwithYardMessage based on the specified Exchange.
      * @param source the source object
      * @param exchange the exchange to use
-     * @param create whether or not we ask the exchange to create a new message, or just get the existing one
      * @return the composed message
      * @throws Exception if a problem happens
      */
-    public Message compose(D source, Exchange exchange, boolean create) throws Exception;
+    public Message compose(D source, Exchange exchange) throws Exception;
 
     /**
      * Takes the data from the SwitchYardMessage in the specified Exchange and decomposes it into the target object.

--- a/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQMessageComposer.java
+++ b/hornetq/src/main/java/org/switchyard/component/hornetq/composer/HornetQMessageComposer.java
@@ -34,8 +34,8 @@ public class HornetQMessageComposer extends BaseMessageComposer<HornetQBindingDa
      * {@inheritDoc}
      */
     @Override
-    public Message compose(HornetQBindingData source, Exchange exchange, boolean create) throws Exception {
-        final Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public Message compose(HornetQBindingData source, Exchange exchange) throws Exception {
+        final Message message = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(message));
         message.setContent(HornetQUtil.readBytes(source.getClientMessage()));
         return message;

--- a/hornetq/src/main/java/org/switchyard/component/hornetq/deploy/InboundHandler.java
+++ b/hornetq/src/main/java/org/switchyard/component/hornetq/deploy/InboundHandler.java
@@ -123,7 +123,7 @@ public class InboundHandler extends BaseServiceHandler implements MessageHandler
             Exchange exchange = _serviceRef.createExchange(getOperationName(bindingData), this);
             Thread.currentThread().setContextClassLoader(_applicationClassLoader);
             _logger.info("onMessage :" + message);
-            exchange.send(_messageComposer.compose(bindingData, exchange, true));
+            exchange.send(_messageComposer.compose(bindingData, exchange));
         } catch (final Exception e) {
             throw new SwitchYardException(e);
         } finally {

--- a/http/src/main/java/org/switchyard/component/http/InboundHandler.java
+++ b/http/src/main/java/org/switchyard/component/http/InboundHandler.java
@@ -105,7 +105,7 @@ public class InboundHandler extends BaseServiceHandler {
         try {
             SynchronousInOutHandler inOutHandler = new SynchronousInOutHandler();
             Exchange exchange = _serviceRef.createExchange(getOperationName(input), inOutHandler);
-            Message message = _messageComposer.compose(input, exchange, true);
+            Message message = _messageComposer.compose(input, exchange);
             SecurityContext.get(exchange).getCredentials().addAll(input.extractCredentials());
             if (exchange.getContract().getConsumerOperation().getExchangePattern() == ExchangePattern.IN_ONLY) {
                 exchange.send(message);

--- a/http/src/main/java/org/switchyard/component/http/OutboundHandler.java
+++ b/http/src/main/java/org/switchyard/component/http/OutboundHandler.java
@@ -165,7 +165,7 @@ public class OutboundHandler extends BaseServiceHandler {
                 httpResponse.setBodyFromStream(entity.getContent());
             }
             httpResponse.setStatus(status);
-            Message out = _messageComposer.compose(httpResponse, exchange, true);
+            Message out = _messageComposer.compose(httpResponse, exchange);
             if (httpResponse.getStatus() < 400) {
                 exchange.send(out);
             } else {

--- a/http/src/main/java/org/switchyard/component/http/composer/HttpMessageComposer.java
+++ b/http/src/main/java/org/switchyard/component/http/composer/HttpMessageComposer.java
@@ -44,8 +44,8 @@ public class HttpMessageComposer extends BaseMessageComposer<HttpBindingData> {
      * {@inheritDoc}
      */
     @Override
-    public Message compose(HttpBindingData source, Exchange exchange, boolean create) throws Exception {
-        final Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public Message compose(HttpBindingData source, Exchange exchange) throws Exception {
+        final Message message = exchange.createMessage();
 
         getContextMapper().mapFrom(source, exchange.getContext(message));
 

--- a/jca/src/main/java/org/switchyard/component/jca/composer/IndexedRecordMessageComposer.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/IndexedRecordMessageComposer.java
@@ -37,9 +37,9 @@ public class IndexedRecordMessageComposer extends BaseMessageComposer<IndexedRec
      * {@inheritDoc}
      */
     @Override
-    public org.switchyard.Message compose(IndexedRecordBindingData source, Exchange exchange, boolean create) throws Exception {
+    public org.switchyard.Message compose(IndexedRecordBindingData source, Exchange exchange) throws Exception {
         
-        final org.switchyard.Message message = create ? exchange.createMessage() : exchange.getMessage();
+        final org.switchyard.Message message = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(message));
         List<Object> l = new ArrayList<Object>();
         l.addAll(source.getRecord());

--- a/jca/src/main/java/org/switchyard/component/jca/composer/JMSMessageComposer.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/JMSMessageComposer.java
@@ -47,8 +47,8 @@ public class JMSMessageComposer extends BaseMessageComposer<JMSBindingData> {
      * {@inheritDoc}
      */
     @Override
-    public org.switchyard.Message compose(JMSBindingData source, Exchange exchange, boolean create) throws Exception {
-        final org.switchyard.Message syMessage = create ? exchange.createMessage() : exchange.getMessage();
+    public org.switchyard.Message compose(JMSBindingData source, Exchange exchange) throws Exception {
+        final org.switchyard.Message syMessage = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(syMessage));
 
         Message jmsMessage = source.getMessage();

--- a/jca/src/main/java/org/switchyard/component/jca/composer/MappedRecordMessageComposer.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/MappedRecordMessageComposer.java
@@ -37,9 +37,8 @@ public class MappedRecordMessageComposer extends BaseMessageComposer<MappedRecor
      * {@inheritDoc}
      */
     @Override
-    public org.switchyard.Message compose(MappedRecordBindingData source, Exchange exchange, boolean create) throws Exception {
-        
-        final org.switchyard.Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public org.switchyard.Message compose(MappedRecordBindingData source, Exchange exchange) throws Exception {
+        final org.switchyard.Message message = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(message));
         Map<Object,Object> m = new HashMap<Object,Object>();
         m.putAll(source.getRecord());

--- a/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposer.java
+++ b/jca/src/main/java/org/switchyard/component/jca/composer/StreamableRecordMessageComposer.java
@@ -39,8 +39,8 @@ public class StreamableRecordMessageComposer extends BaseMessageComposer<Streama
      * {@inheritDoc}
      */
     @Override
-    public Message compose(StreamableRecordBindingData source, Exchange exchange, boolean create) throws Exception {
-        final org.switchyard.Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public Message compose(StreamableRecordBindingData source, Exchange exchange) throws Exception {
+        final org.switchyard.Message message = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(message));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream(); 

--- a/jca/src/main/java/org/switchyard/component/jca/endpoint/CCIEndpoint.java
+++ b/jca/src/main/java/org/switchyard/component/jca/endpoint/CCIEndpoint.java
@@ -74,7 +74,7 @@ public class CCIEndpoint extends AbstractInflowEndpoint implements MessageListen
             MappedRecordBindingData bindingData = new MappedRecordBindingData(sourceRecord);
             String operation = _selector != null ? _selector.selectOperation(bindingData).getLocalPart() : null;
             Exchange exchange = createExchange(operation, inOutHandler);
-            exchange.send(_composer.compose(bindingData, exchange, true));
+            exchange.send(_composer.compose(bindingData, exchange));
 
             exchange = inOutHandler.waitForOut(_waitTimeout);
             MappedRecord returnRecord = _recordFactory.createMappedRecord(_recordName);

--- a/jca/src/main/java/org/switchyard/component/jca/endpoint/JMSEndpoint.java
+++ b/jca/src/main/java/org/switchyard/component/jca/endpoint/JMSEndpoint.java
@@ -51,7 +51,7 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
             JMSBindingData bindingData = new JMSBindingData(message);
             final String operation = _selector != null ? _selector.selectOperation(bindingData).getLocalPart() : null;
             final Exchange exchange = createExchange(operation);
-            exchange.send(_composer.compose(bindingData, exchange, true));
+            exchange.send(_composer.compose(bindingData, exchange));
         } catch (Exception e) {
             throw new SwitchYardException(e);
         }

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/IndexedRecordHandler.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/IndexedRecordHandler.java
@@ -38,6 +38,6 @@ public class IndexedRecordHandler extends RecordHandler<IndexedRecordBindingData
     public Message handle(Exchange exchange, Connection conn, Interaction interact) throws Exception {
         IndexedRecord record = getRecordFactory().createIndexedRecord(IndexedRecordHandler.class.getName());
         IndexedRecord outRecord = (IndexedRecord) interact.execute(getInteractionSpec(), getMessageComposer(IndexedRecordBindingData.class).decompose(exchange, new IndexedRecordBindingData(record)).getRecord());
-        return getMessageComposer(IndexedRecordBindingData.class).compose(new IndexedRecordBindingData(outRecord), exchange, true);
+        return getMessageComposer(IndexedRecordBindingData.class).compose(new IndexedRecordBindingData(outRecord), exchange);
     }
 }

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/MappedRecordHandler.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/MappedRecordHandler.java
@@ -38,6 +38,6 @@ public class MappedRecordHandler extends RecordHandler<MappedRecordBindingData> 
     public Message handle(Exchange exchange, Connection conn, Interaction interact) throws Exception {
         MappedRecord record = getRecordFactory().createMappedRecord(MappedRecordHandler.class.getName());
         MappedRecord outRecord = (MappedRecord) interact.execute(getInteractionSpec(), getMessageComposer(MappedRecordBindingData.class).decompose(exchange, new MappedRecordBindingData(record)).getRecord());
-        return getMessageComposer(MappedRecordBindingData.class).compose(new MappedRecordBindingData(outRecord), exchange, true);
+        return getMessageComposer(MappedRecordBindingData.class).compose(new MappedRecordBindingData(outRecord), exchange);
     }
 }

--- a/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecordHandler.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/cci/StreamableRecordHandler.java
@@ -38,7 +38,7 @@ public class StreamableRecordHandler extends RecordHandler<StreamableRecordBindi
         StreamableRecord record = new StreamableRecord();
         StreamableRecord outRecord = new StreamableRecord();
         interact.execute(getInteractionSpec(), getMessageComposer(StreamableRecordBindingData.class).decompose(exchange, new StreamableRecordBindingData(record)).getRecord(), outRecord);
-        return getMessageComposer(StreamableRecordBindingData.class).compose(new StreamableRecordBindingData(outRecord), exchange, true);
+        return getMessageComposer(StreamableRecordBindingData.class).compose(new StreamableRecordBindingData(outRecord), exchange);
     }
 
 }

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/MyJMSMessageComposer.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/MyJMSMessageComposer.java
@@ -7,8 +7,8 @@ import org.switchyard.component.jca.composer.JMSMessageComposer;
 public class MyJMSMessageComposer extends JMSMessageComposer {
 
     @Override
-    public org.switchyard.Message compose(JMSBindingData source, Exchange exchange, boolean create) throws Exception {
-        org.switchyard.Message msg = super.compose(source, exchange, create);
+    public org.switchyard.Message compose(JMSBindingData source, Exchange exchange) throws Exception {
+        org.switchyard.Message msg = super.compose(source, exchange);
         msg.setContent(msg.getContent(String.class) + "test");
         return msg;
     }

--- a/resteasy/src/main/java/org/switchyard/component/resteasy/InboundHandler.java
+++ b/resteasy/src/main/java/org/switchyard/component/resteasy/InboundHandler.java
@@ -98,7 +98,7 @@ public class InboundHandler extends BaseServiceHandler {
         Exchange exchange = _service.createExchange(restMessageRequest.getOperationName(), inOutHandler);
         Message message = null;
         try {
-            message = _messageComposer.compose(restMessageRequest, exchange, true);
+            message = _messageComposer.compose(restMessageRequest, exchange);
         } catch (Exception e) {
             LOGGER.error("Unexpected exception composing inbound Message", e);
             return output;

--- a/resteasy/src/main/java/org/switchyard/component/resteasy/OutboundHandler.java
+++ b/resteasy/src/main/java/org/switchyard/component/resteasy/OutboundHandler.java
@@ -129,7 +129,7 @@ public class OutboundHandler extends BaseServiceHandler {
 
         try {
             restResponse.setOperationName(opName);
-            Message out = _messageComposer.compose(restResponse, exchange, true);
+            Message out = _messageComposer.compose(restResponse, exchange);
             // Our transformer magic transforms the entity appropriately here :)
             exchange.send(out);
         } catch (Exception e) {

--- a/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyMessageComposer.java
+++ b/resteasy/src/main/java/org/switchyard/component/resteasy/composer/RESTEasyMessageComposer.java
@@ -37,8 +37,8 @@ public class RESTEasyMessageComposer extends BaseMessageComposer<RESTEasyBinding
      * {@inheritDoc}
      */
     @Override
-    public Message compose(RESTEasyBindingData source, Exchange exchange, boolean create) throws Exception {
-        final Message message = create ? exchange.createMessage() : exchange.getMessage();
+    public Message compose(RESTEasyBindingData source, Exchange exchange) throws Exception {
+        final Message message = exchange.createMessage();
         getContextMapper().mapFrom(source, exchange.getContext(message));
         Object content = null;
         if (source.getParameters().length > 0) {

--- a/soap/src/main/java/org/switchyard/component/soap/InboundHandler.java
+++ b/soap/src/main/java/org/switchyard/component/soap/InboundHandler.java
@@ -194,7 +194,7 @@ public class InboundHandler extends BaseServiceHandler {
 
             Message message;
             try {
-                message = _messageComposer.compose(soapBindingData, exchange, true);
+                message = _messageComposer.compose(soapBindingData, exchange);
             } catch (Exception e) {
                 throw e instanceof SOAPException ? (SOAPException)e : new SOAPException(e);
             }

--- a/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
+++ b/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
@@ -162,7 +162,7 @@ public class OutboundHandler extends BaseServiceHandler {
                         faultInfo.copyFaultInfo(response);
                         bindingData.setSOAPFaultInfo(faultInfo);
                     }
-                    message = _messageComposer.compose(bindingData, exchange, true);
+                    message = _messageComposer.compose(bindingData, exchange);
                 } catch (Exception e) {
                     throw e instanceof SOAPException ? (SOAPException)e : new SOAPException(e);
                 }

--- a/soap/src/main/java/org/switchyard/component/soap/composer/SOAPMessageComposer.java
+++ b/soap/src/main/java/org/switchyard/component/soap/composer/SOAPMessageComposer.java
@@ -78,9 +78,9 @@ public class SOAPMessageComposer extends BaseMessageComposer<SOAPBindingData> {
      * {@inheritDoc}
      */
     @Override
-    public Message compose(SOAPBindingData source, Exchange exchange, boolean create) throws Exception {
+    public Message compose(SOAPBindingData source, Exchange exchange) throws Exception {
         final SOAPMessage soapMessage = source.getSOAPMessage();
-        final Message message = create ? exchange.createMessage() : exchange.getMessage();
+        final Message message = exchange.createMessage();
         final Boolean input = exchange.getPhase() == null;
 
         getContextMapper().mapFrom(source, exchange.getContext(message));


### PR DESCRIPTION
Split hierarchy tree for Camel Component and Camel Binding Components.
Removal of SERVICE_DOMAIN camel property and registry lookups since we use SwitchYardCamelContext everywhere which has getServiceDomain method.
