### PR TITLE
SWITCHYARD-1365 beanshell bsh version

### DIFF
--- a/camel/component/pom.xml
+++ b/camel/component/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>camel-script</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency> 
+            <groupId>org.beanshell</groupId>
+            <artifactId>bsh</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-common-camel</artifactId>


### PR DESCRIPTION
Downgrade bsh to 2.0b4 to align with EAP.
