### PR TITLE
SWITCHYARD-1414: Add ability to reference named security sections

### DIFF
--- a/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTest.java
+++ b/camel/camel-switchyard/src/test/java/org/switchyard/component/camel/SwitchYardComponentTest.java
@@ -109,7 +109,7 @@ public class SwitchYardComponentTest extends SwitchYardComponentTestBase {
     public void customBindingData() throws Exception {
         List<Policy> policies = Arrays.<Policy>asList(SecurityPolicy.CONFIDENTIALITY);
         final MockHandler mockService = new MockHandler();
-        _serviceDomain.registerService(new QName(_serviceName), new InOnlyService(), mockService, policies, new Binding(null));
+        _serviceDomain.registerService(new QName(_serviceName), new InOnlyService(), mockService, policies, null, new Binding(null));
         _serviceDomain.registerServiceReference(new QName(_serviceName), new InOnlyService("process"));
         _camelContext.addRoutes(new RouteBuilder() {
             @Override


### PR DESCRIPTION
SWITCHYARD-1414: Add ability to reference named security sections
https://issues.jboss.org/browse/SWITCHYARD-1414
