### PR TITLE
[SWITCHYARD - 1507] RecipientList requires explicit Namespace parameter ...

### DIFF
--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelRoutingSlipNSInjectionTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelRoutingSlipNSInjectionTest.java
@@ -1,0 +1,71 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @author tags. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details. 
+ * You should have received a copy of the GNU Lesser General Public License, 
+ * v.2.1 along with this distribution; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA  02110-1301, USA.
+ */
+package org.switchyard.component.camel.deploy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RecipientListDefinition;
+import org.apache.camel.model.RouteDefinition;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+
+/**
+ * @author Ashwin Karpe &lt;<a href="mailto:akarpe@jboss.org">akarpe@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(config = "switchyard-routingslip-ns-injection-test.xml", mixins = CDIMixIn.class)
+public class CamelRoutingSlipNSInjectionTest {
+    private final static String MATH_SERVICE = "CamelMathService";
+
+    private SwitchYardCamelContext _camelContext;
+
+    @ServiceOperation(MATH_SERVICE)
+    private Invoker invoker;
+
+    @Before
+    public void verifyContext() {
+        assertNotNull(_camelContext.getServiceDomain());
+    }
+
+    @Test
+    public void autoInjectedNamespaceinReceipientList() throws Exception {
+        String uri = null;
+        
+        // Route is already instantiated at this point and the camel context 
+        // should contain the namespace updated route definition
+        RouteDefinition routeDefinition = _camelContext.getRouteDefinition("CamelMathRoute");
+        for (ProcessorDefinition<?> processorDefinition : routeDefinition.getOutputs()) {
+            if (processorDefinition instanceof RecipientListDefinition) {
+                uri = ((RecipientListDefinition)processorDefinition).getExpression().getExpression();
+            }
+        }
+        
+        assertEquals("switchyard://MathAll?namespace=urn:camel-core:test:1.0", uri);
+        
+    }
+}

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/routingslip-ns-injection-test.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/routingslip-ns-injection-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<routes xmlns="http://camel.apache.org/schema/spring">
+    <route id="CamelMathRoute">
+        <from uri="switchyard://CamelMathService"/>
+        <to uri="log:test?showAll=true" />
+        <recipientList>
+	 	    <simple>switchyard://MathAll</simple>
+    	</recipientList>
+    </route>
+</routes>

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-routingslip-ns-injection-test.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/switchyard-routingslip-ns-injection-test.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- JBoss, Home of Professional Open Source Copyright 2011 Red Hat Inc. 
+    and/or its affiliates and other contributors as indicated by the @authors 
+    tag. All rights reserved. See the copyright.txt in the distribution for a 
+    full listing of individual contributors. This copyrighted material is made 
+    available to anyone wishing to use, modify, copy, or redistribute it subject 
+    to the terms and conditions of the GNU Lesser General Public License, v. 
+    2.1. This program is distributed in the hope that it will be useful, but 
+    WITHOUT A WARRANTY; without even the implied warranty of MERCHANTABILITY 
+    or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License 
+    for more details. You should have received a copy of the GNU Lesser General 
+    Public License, v.2.1 along with this distribution; if not, write to the 
+    Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+    MA 02110-1301, USA. -->
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+    xmlns:camel="urn:switchyard-component-camel:config:1.0"
+    xmlns:core="urn:switchyard-component-camel-core:config:1.0">
+
+    <sca:composite name="MathComposite" targetNamespace="urn:camel-core:test:1.0">
+        <sca:service name="CamelMathService" promote="MathComponent/CamelMathService" />
+
+        <sca:component name="MathComponent">
+            <camel:implementation.camel xmlns="urn:switchyard-component-camel:config:1.0">
+	         <xml path="org/switchyard/component/camel/deploy/routingslip-ns-injection-test.xml"/> 
+            </camel:implementation.camel>
+
+            <sca:service name="CamelMathService">
+                <sca:interface.java interface="org.switchyard.component.camel.deploy.support.MathService"/>
+            </sca:service>
+
+            <sca:reference name="MathAll">
+                <interface.esb inputType="java:java.lang.Double" />
+            </sca:reference>
+            <sca:reference name="MathCos">
+                <interface.esb inputType="java:java.lang.Double" />
+            </sca:reference>
+            <sca:reference name="MathAbs">
+                <interface.esb inputType="java:java.lang.Double" />
+            </sca:reference>
+        </sca:component>
+
+        <sca:reference name="MathAll" multiplicity="0..1" promote="MathAll">
+            <interface.esb inputType="java:java.lang.Double" />
+            <core:binding.mock>
+                <core:name>all</core:name>
+            </core:binding.mock>
+        </sca:reference>
+        <sca:reference name="MathAbs" multiplicity="0..1" promote="MathAbs">
+            <interface.esb inputType="java:java.lang.Double" />
+            <core:binding.mock>
+                <core:name>abs</core:name>
+            </core:binding.mock>
+        </sca:reference>
+        <sca:reference name="MathCos" multiplicity="0..1" promote="MathCos">
+            <interface.esb inputType="java:java.lang.Double" />
+            <core:binding.mock>
+                <core:name>cos</core:name>
+            </core:binding.mock>
+        </sca:reference>
+    </sca:composite>
+
+</switchyard>

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/SwitchYardRouteDefinition.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/SwitchYardRouteDefinition.java
@@ -28,6 +28,7 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.impl.DefaultEndpoint;
 import org.apache.camel.model.FromDefinition;
 import org.apache.camel.model.ProcessorDefinition;
+import org.apache.camel.model.RecipientListDefinition;
 import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.ToDefinition;
 import org.switchyard.common.lang.Strings;
@@ -136,6 +137,14 @@ public final class SwitchYardRouteDefinition extends RouteDefinition {
             String new_uri = addNamespaceParameter(old_uri, namespace);
             toDef.setUri(new_uri);
             setEndpointUri(toDef.getEndpoint(), namespace);
+        } else if (procDef instanceof RecipientListDefinition) {
+            RecipientListDefinition<?> recipientListDefinition = (RecipientListDefinition<?>)procDef;
+            String expression = recipientListDefinition.getExpression().getExpression();
+            if ((expression.contains("switchyard://")) && (expression.contains("?"))) {
+                recipientListDefinition.getExpression().setExpression(expression + "&namespace=" + namespace);
+            } else if ((expression.contains("switchyard://")) && (!expression.contains("?"))) {
+                recipientListDefinition.getExpression().setExpression(expression + "?namespace=" + namespace);
+            }
         }
         for (ProcessorDefinition<?> procDefChild : procDef.getOutputs()) {
             addNamespaceParameterTo(procDefChild, namespace);


### PR DESCRIPTION
...to be passed in the Endpoint UR

Fixed the recipientList namespace issue at the source. The recipeintList namespaces are resolved while loading the route definitions prior to route startup. 
Added unit tests to prove it works. Passes checkstyle.
