### PR TITLE
[SWITCHYARD-1556] - in-out remote invocations in cluster reuse same mess...

### DIFF
--- a/sca/src/main/java/org/switchyard/component/sca/SCAInvoker.java
+++ b/sca/src/main/java/org/switchyard/component/sca/SCAInvoker.java
@@ -143,7 +143,11 @@ public class SCAInvoker extends BaseServiceHandler {
         try {
             RemoteMessage reply = _invoker.invoke(request);
             if (isInOut(exchange) && reply != null) {
-                Message msg = exchange.getMessage().setContent(reply.getContent());
+                Message msg = exchange.createMessage();
+                msg.setContent(reply.getContent());
+                if (reply.getContext() != null) {
+                    msg.getContext().setProperties(reply.getContext().getProperties());
+                }
                 if (reply.isFault()) {
                     exchange.sendFault(msg);
                 } else {


### PR DESCRIPTION
...age instance

Fixed and verified using switchyard cluster demo as baseline (quickstarts/demos/cluster). The fix eliminates the reuse of the same message during a remote invocation via SCAInvoker (java.lang.IllegalArgumentException: Can not send same message twice). 

Ensured that context properties from the invocation on the reply message continue to be propagated.

Passes check style.
