### PR TITLE
SWITCHYARD-1550 SwitchYardProducer does not prune transient context properties in camel routes

### DIFF
--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/ExchangeMapper.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/ExchangeMapper.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2013, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.component.camel;
+
+import javax.activation.DataHandler;
+
+import org.apache.camel.impl.DefaultMessage;
+import org.switchyard.ExchangePhase;
+import org.switchyard.Property;
+import org.switchyard.Scope;
+import org.switchyard.common.camel.ContextPropertyUtil;
+import org.switchyard.common.camel.HandlerDataSource;
+import org.switchyard.common.camel.SwitchYardMessage;
+import org.switchyard.label.BehaviorLabel;
+
+/**
+ * ExchangeMapper handles the mapping between SwitchYard and Camel exchanges when used from a Camel
+ * implementation.  This mapping is distinct from what message composers do with gateways for two
+ * reasons: 
+ * 1) Gateway composers are configurable by users. Internal mapping between exchanges
+ * within a camel implementation should not be configurable.
+ * 2) The mapping rules for gateways and implementations can differ in subtle ways.  For example,
+ * transient context properties propagate from gateway routes with SwitchYardProducer, but this should
+ * not happen in implementation routes as it allows exchange properties to leak between multiple 
+ * switchyard:// endpoint invocations.
+ */
+public final class ExchangeMapper {
+    
+    private ExchangeMapper() {
+        
+    }
+
+    /**
+     * Map from a camel exchange to a SwitchYard exchange.
+     * @param camelExchange the camel exchange
+     * @param syExchange the switchyard exchange
+     * @param phase ExchangePhase.IN to target camelExchange.getIn(), ExchangePhase.OUT to 
+     * target camelExchange.getIn().
+     * @return the 
+     */
+    public static org.switchyard.Message mapCamelToSwitchYard(
+            org.apache.camel.Exchange camelExchange,
+            org.switchyard.Exchange syExchange,
+            ExchangePhase phase) {
+        
+        // Associate the correct Camel message with the SY exchange
+        org.switchyard.Message message = syExchange.createMessage();
+        org.apache.camel.Message camelMessage;
+        if (phase.equals(ExchangePhase.OUT) && camelExchange.hasOut()) {
+            camelMessage = camelExchange.getOut();
+        } else {
+            camelMessage = camelExchange.getIn();
+        }
+        message.setContent(camelMessage.getBody());
+        
+        for (String property : camelExchange.getProperties().keySet()) {
+            if (ContextPropertyUtil.isReservedProperty(property, Scope.EXCHANGE)) {
+                continue;
+            }
+            // skip the implementation route property as we don't want that propagated
+            if (SwitchYardConsumer.IMPLEMENTATION_ROUTE.equals(property)) {
+                continue;
+            }
+            
+            message.getContext().setProperty(property, camelExchange.getProperty(property), Scope.EXCHANGE);
+        }
+        for (String header : camelMessage.getHeaders().keySet()) {
+            if (ContextPropertyUtil.isReservedProperty(header, Scope.MESSAGE)) {
+                continue;
+            }
+            message.getContext().setProperty(header, camelMessage.getHeader(header), Scope.MESSAGE);
+        }
+
+        for (String attachmentName : camelMessage.getAttachmentNames()) {
+            message.addAttachment(attachmentName, new HandlerDataSource(camelMessage.getAttachment(attachmentName)));
+        }
+        
+        return message;
+    }
+    
+    /**
+     * Maps a SwitchYard exchange to a Camel exchange.  Keep in mind that the camel message created
+     * during mapping is *not* associate with the exchange.  You need to call setIn() or setOut() 
+     * with the returned reference depending on your use case.
+     * @param syExchange switchyard exchange
+     * @param camelExchange camel exchange
+     * @return mapped camel message
+     */
+    public static DefaultMessage mapSwitchYardToCamel(
+            org.switchyard.Exchange syExchange,
+            org.apache.camel.Exchange camelExchange) {
+        
+        DefaultMessage camelMessage = new SwitchYardMessage();
+        camelMessage.setBody(syExchange.getMessage().getContent());
+
+        for (Property property : syExchange.getContext().getProperties()) {
+            if (property.hasLabel(BehaviorLabel.TRANSIENT.label()) 
+                    || ContextPropertyUtil.isReservedProperty(property.getName(), property.getScope())) {
+                continue;
+            }
+
+            if (Scope.EXCHANGE.equals(property.getScope())) {
+                camelExchange.setProperty(property.getName(), property.getValue());
+            } else {
+                camelMessage.setHeader(property.getName(), property.getValue());
+            }
+        }
+        
+        for (String attachmentName : syExchange.getMessage().getAttachmentMap().keySet()) {
+            camelMessage.addAttachment(attachmentName, 
+                    new DataHandler(syExchange.getMessage().getAttachment(attachmentName)));
+        }
+        
+        return camelMessage;
+    }
+}

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelMathTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelMathTest.java
@@ -70,18 +70,18 @@ public class CamelMathTest {
         all.expectedMessageCount(2);
         all.expectedBodiesReceived(100.0, 101.0);
         // in this case 
-        all.expectedHeaderReceived(Exchange.SERVICE_NAME, MATH_ALL_SERVICE_NS);
-        all.expectedHeaderReceived(Exchange.SERVICE_NAME, MATH_ALL_SERVICE_NS);
+        all.expectedPropertyReceived(Exchange.SERVICE_NAME, MATH_ALL_SERVICE_NS);
+        all.expectedPropertyReceived(Exchange.SERVICE_NAME, MATH_ALL_SERVICE_NS);
 
         MockEndpoint cos = _camelContext.getEndpoint("mock:cos", MockEndpoint.class);
         cos.expectedMessageCount(1);
         cos.expectedBodiesReceived(101.0);
-        cos.expectedHeaderReceived(Exchange.SERVICE_NAME, MATH_COS_SERVICE_NS);
+        cos.expectedPropertyReceived(Exchange.SERVICE_NAME, MATH_COS_SERVICE_NS);
 
         MockEndpoint abs = _camelContext.getEndpoint("mock:abs", MockEndpoint.class);
         abs.expectedMessageCount(1);
         abs.expectedBodiesReceived(100.0);
-        abs.expectedHeaderReceived(Exchange.SERVICE_NAME, MATH_ABS_SERVICE_NS);
+        abs.expectedPropertyReceived(Exchange.SERVICE_NAME, MATH_ABS_SERVICE_NS);
 
         invoker.operation("abs").sendInOut(100.0);
         invoker.operation("cos").sendInOut(101.0);
@@ -96,9 +96,9 @@ public class CamelMathTest {
     public void shouldReahUnknown() throws Exception {
         MockEndpoint unknown = _camelContext.getEndpoint("mock:unknown", MockEndpoint.class);
         unknown.expectedBodiesReceived(10.1);
-        unknown.expectedHeaderReceived(Exchange.OPERATION_NAME, "pow");
-        unknown.expectedHeaderReceived(Exchange.SERVICE_NAME, MATH_SERVICE_NS);
-        unknown.expectedHeaderReceived(Exchange.FAULT_TYPE, "java:" + IllegalArgumentException.class.getName());
+        unknown.expectedPropertyReceived(Exchange.OPERATION_NAME, "pow");
+        unknown.expectedPropertyReceived(Exchange.SERVICE_NAME, MATH_SERVICE_NS);
+        unknown.expectedPropertyReceived(Exchange.FAULT_TYPE, "java:" + IllegalArgumentException.class.getName());
 
         invoker.operation("pow").sendInOut(10.1);
 

--- a/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
+++ b/camel/component/src/test/java/org/switchyard/component/camel/deploy/CamelProxyTest.java
@@ -58,16 +58,24 @@ public class CamelProxyTest {
     @Test
     public void shouldInvokeDifferentOperations() throws Exception {
         MockEndpoint all = _camelContext.getEndpoint("mock:all", MockEndpoint.class);
-        all.expectedBodiesReceived(100.0, 101.0, 11.0);
-
-        all.message(0).header(Exchange.OPERATION_NAME).isEqualTo("abs");
-        all.message(1).header(Exchange.OPERATION_NAME).isEqualTo("cos");
-        all.message(2).header(Exchange.OPERATION_NAME).isEqualTo("pow");
-
-        invoker.operation("abs").sendInOut(100.0);
+        
+        all.expectedBodiesReceived(100.0);
+        all.expectedPropertyReceived(Exchange.OPERATION_NAME, "pow");
+        invoker.operation("pow").sendInOut(100.0);
+        all.assertIsSatisfied();
+        
+        all.reset();
+        
+        all.expectedBodiesReceived(101.0);
+        all.expectedPropertyReceived(Exchange.OPERATION_NAME, "cos");
         invoker.operation("cos").sendInOut(101.0);
-        invoker.operation("pow").sendInOut(11.0);
+        all.assertIsSatisfied();
 
+        all.reset();
+        
+        all.expectedBodiesReceived(11.0);
+        all.expectedPropertyReceived(Exchange.OPERATION_NAME, "pow");
+        invoker.operation("pow").sendInOut(11.0);
         all.assertIsSatisfied();
     }
 

--- a/camel/component/src/test/resources/org/switchyard/component/camel/deploy/math-route.xml
+++ b/camel/component/src/test/resources/org/switchyard/component/camel/deploy/math-route.xml
@@ -26,11 +26,11 @@
         <to uri="log:test?showAll=true" />
         <choice>
             <when>
-                <simple>${header.org.switchyard.operationName} == 'cos'</simple>
+                <simple>${property.org.switchyard.operationName} == 'cos'</simple>
                 <to uri="direct:cos" />
             </when>
             <when>
-                <simple>${header.org.switchyard.operationName} == 'abs'</simple>
+                <simple>${property.org.switchyard.operationName} == 'abs'</simple>
                 <to uri="direct:abs" />
             </when>
             <otherwise>

--- a/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelMessageComposer.java
+++ b/common/camel/src/main/java/org/switchyard/component/camel/common/composer/CamelMessageComposer.java
@@ -102,9 +102,9 @@ public class CamelMessageComposer extends BaseMessageComposer<CamelBindingData> 
         }
 
         ServiceOperation operation = exchange.getContract().getProviderOperation();
-        targetMessage.setHeader(OPERATION_NAME, operation.getName());
-        targetMessage.setHeader(FAULT_TYPE, operation.getFaultType());
-        targetMessage.setHeader(SERVICE_NAME, exchange.getProvider().getName());
+        target.getMessage().getExchange().setProperty(OPERATION_NAME, operation.getName());
+        target.getMessage().getExchange().setProperty(FAULT_TYPE, operation.getFaultType());
+        target.getMessage().getExchange().setProperty(SERVICE_NAME, exchange.getProvider().getName());
 
         targetMessage.setBody(sourceMessage.getContent());
         return target;


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1550
