### PR TITLE
SWITCHYARD-1592: schema "from" attribute in bpm and rules variable mappings should be optional

### DIFF
--- a/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
+++ b/bpm/src/main/resources/org/switchyard/component/bpm/config/model/v1/bpm-v1.xsd
@@ -242,7 +242,7 @@
     <complexType name="MappingType">
         <complexContent>
             <extension base="sca:CommonExtensionBase">
-                <attribute name="from" type="string" use="required"/>
+                <attribute name="from" type="string" use="optional"/>
                 <attribute name="to" type="string" use="optional"/>
             </extension>
         </complexContent>

--- a/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
+++ b/rules/src/main/resources/org/switchyard/component/rules/config/model/v1/rules-v1.xsd
@@ -238,7 +238,7 @@
     <complexType name="MappingType">
         <complexContent>
             <extension base="sca:CommonExtensionBase">
-                <attribute name="from" type="string" use="required"/>
+                <attribute name="from" type="string" use="optional"/>
                 <attribute name="to" type="string" use="optional"/>
             </extension>
         </complexContent>


### PR DESCRIPTION
SWITCHYARD-1592: schema "from" attribute in bpm and rules variable mappings should be optional
https://issues.jboss.org/browse/SWITCHYARD-1592
