### PR TITLE
SWITCHYARD-1630 SOAP component: TRACE log in OutboundHandler.handleMessage(..) doesn't output response message correctly

### DIFF
--- a/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
+++ b/soap/src/main/java/org/switchyard/component/soap/OutboundHandler.java
@@ -256,6 +256,9 @@ public class OutboundHandler extends BaseServiceHandler {
                 LOGGER.trace("Outbound ---> Request:[" + SOAPUtil.soapMessageToString(request) + "]" + (oneWay ? " oneWay " : ""));
             }
             SOAPMessage response = invokeService(request, oneWay, action);
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Outbound <--- Response:[" + SOAPUtil.soapMessageToString(response) + "]");
+            }
             if (response != null) {
                 // This property vanishes once message composer processes this message
                 // so caching it here
@@ -281,10 +284,6 @@ public class OutboundHandler extends BaseServiceHandler {
                 } else {
                     exchange.send(message);
                 }
-            }
-
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Outbound <--- Response:[" + SOAPUtil.soapMessageToString(response) + "]");
             }
 
         } catch (SOAPException se) {


### PR DESCRIPTION
[https://issues.jboss.org/browse/SWITCHYARD-1630](https://issues.jboss.org/browse/SWITCHYARD-1630)
Just moved the trace logging part to immediately after the `response` object is returned, as `SOAPMessageComposer.compose(..)` method, which is invoked then, imposes destructive effects on the `response` object. 
