### PR TITLE
Enable CDI in SwitchYard unit tests

### DIFF
--- a/test/mixins/cdi/src/test/java/org/switchyard/component/test/mixins/cdi/CDIMixInInjectionTest.java
+++ b/test/mixins/cdi/src/test/java/org/switchyard/component/test/mixins/cdi/CDIMixInInjectionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.switchyard.component.test.mixins.cdi;
+
+import javax.inject.Inject;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+
+class ExampleBean {
+}
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
+public class CDIMixInInjectionTest {
+
+    @Inject
+    private ExampleBean exampleBean;
+
+    @Test
+    public void test() {
+        Assert.assertNotNull(exampleBean);
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-1645

This enhancement extends the CDIMixIn to allow the use of CDI in SwitchYard unit tests including, but not limited to @Inject. See https://community.jboss.org/thread/231512 for details.
