### PR TITLE
[SWITCHYARD-1599] - Add trigger.timeZone parameter to Scheduler gateway

### DIFF
--- a/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/model/CamelQuartzBindingModel.java
+++ b/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/model/CamelQuartzBindingModel.java
@@ -94,4 +94,16 @@ public interface CamelQuartzBindingModel extends CamelBindingModel {
      */
     CamelQuartzBindingModel setEndTime(Date endTime);
 
+    /**
+     * Returns the schedule timezone.
+     * @return timeZone corresponding to the schedule timezone.
+     */
+    String getTimeZone();
+    
+    /**
+     * Sets the schedule timezone.
+     * @param timeZone String corresponding to the schedule timezone.
+     * @return a reference to this config model
+     */
+    CamelQuartzBindingModel setTimeZone(String timeZone);
 }

--- a/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/model/v1/V1CamelQuartzBindingModel.java
+++ b/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/model/v1/V1CamelQuartzBindingModel.java
@@ -41,6 +41,7 @@ public class V1CamelQuartzBindingModel extends V1BaseCamelBindingModel
     private static final String STATEFUL = "stateful";
     private static final String START_TIME = "trigger.startTime";
     private static final String END_TIME = "trigger.endTime";
+    private static final String TIMEZONE = "trigger.timeZone";
 
     // Used for dateTime fields
     private static DateFormat _dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
@@ -51,7 +52,7 @@ public class V1CamelQuartzBindingModel extends V1BaseCamelBindingModel
     public V1CamelQuartzBindingModel() {
         super(QUARTZ, QUARTZ_NAMESPACE_V1);
 
-        setModelChildrenOrder(NAME, CRON, STATEFUL, START_TIME, END_TIME);
+        setModelChildrenOrder(NAME, CRON, STATEFUL, START_TIME, END_TIME, TIMEZONE);
     }
 
     /**
@@ -114,6 +115,16 @@ public class V1CamelQuartzBindingModel extends V1BaseCamelBindingModel
         return setConfig(END_TIME, _dateFormat.format(endTime));
     }
 
+    @Override
+    public String getTimeZone() {
+        return getConfig(TIMEZONE);
+    }
+
+    @Override
+    public V1CamelQuartzBindingModel setTimeZone(String timeZone) {
+        return setConfig(TIMEZONE, timeZone);
+    }
+    
     @Override
     public URI getComponentURI() {
         Configuration modelConfiguration = getModelConfiguration();

--- a/camel/camel-quartz/src/main/resources/org/switchyard/component/camel/quartz/model/v1/camel-quartz-v1.xsd
+++ b/camel/camel-quartz/src/main/resources/org/switchyard/component/camel/quartz/model/v1/camel-quartz-v1.xsd
@@ -32,6 +32,7 @@
                     <element name="stateful" type="boolean" minOccurs="0" maxOccurs="1" />
                     <element name="trigger.startTime" type="dateTime" minOccurs="0" maxOccurs="1" />
                     <element name="trigger.endTime" type="dateTime" minOccurs="0" maxOccurs="1" />
+                    <element name="trigger.timeZone" type="string" minOccurs="0" maxOccurs="1" />
                 </sequence>
             </extension>
         </complexContent>

--- a/camel/camel-quartz/src/test/java/org/switchyard/component/camel/quartz/model/v1/V1CamelQuartzBindingModelTest.java
+++ b/camel/camel-quartz/src/test/java/org/switchyard/component/camel/quartz/model/v1/V1CamelQuartzBindingModelTest.java
@@ -39,14 +39,16 @@ public class V1CamelQuartzBindingModelTest extends V1BaseCamelServiceBindingMode
     private static final Boolean STATEFUL = true;
     private static Date START_TIME;
     private static Date END_TIME;
+    private static String TIMEZONE;
 
     private static final String CAMEL_URI = "quartz://MyJob?cron=0 0 12 * * ?&stateful=true" +
-        "&trigger.startTime=2011-01-01T12:00:00&trigger.endTime=2011-01-01T12:00:00";
+        "&trigger.startTime=2011-01-01T12:00:00&trigger.endTime=2011-01-01T12:00:00&trigger.timeZone=America/New_York";
 
     static {
         try {
             START_TIME = _dateFormat.parse("2011-01-01T12:00:00");
             END_TIME = _dateFormat.parse("2011-01-01T12:00:00");
+            TIMEZONE = "America/New_York";
         } catch (Exception e) { /* ignore */ }
     }
 
@@ -63,7 +65,8 @@ public class V1CamelQuartzBindingModelTest extends V1BaseCamelServiceBindingMode
             .setCron(CRON)
             .setStateful(STATEFUL)
             .setStartTime(START_TIME)
-            .setEndTime(END_TIME);
+            .setEndTime(END_TIME)
+            .setTimeZone(TIMEZONE);
     }
 
     @Override
@@ -73,6 +76,7 @@ public class V1CamelQuartzBindingModelTest extends V1BaseCamelServiceBindingMode
         assertEquals(STATEFUL, model.isStateful());
         assertEquals(START_TIME, model.getStartTime());
         assertEquals(END_TIME, model.getEndTime());
+        assertEquals(TIMEZONE, model.getTimeZone());
     }
 
     @Override

--- a/camel/camel-quartz/src/test/resources/v1/switchyard-quartz-binding-beans.xml
+++ b/camel/camel-quartz/src/test/resources/v1/switchyard-quartz-binding-beans.xml
@@ -24,6 +24,7 @@
                 <quartz:stateful>true</quartz:stateful>
                 <quartz:trigger.startTime>2011-01-01T12:00:00</quartz:trigger.startTime>
                 <quartz:trigger.endTime>2011-01-01T12:00:00</quartz:trigger.endTime>
+                <quartz:trigger.timeZone>America/New_York</quartz:trigger.timeZone>
             </quartz:binding.quartz>
         </sca:service>
     </sca:composite>


### PR DESCRIPTION
Added the capability to add a timeZone to the Scheduler gateway. Code passes checkstyle and I have updated the existing unit test to validate that timezone is correctly applied and works. 
