### PR TITLE
[SWITCHYARD-1631] - JMS binding configuration is missing ack mode

### DIFF
--- a/camel/camel-jms/src/main/java/org/switchyard/component/camel/jms/model/CamelJmsBindingModel.java
+++ b/camel/camel-jms/src/main/java/org/switchyard/component/camel/jms/model/CamelJmsBindingModel.java
@@ -360,5 +360,37 @@ public interface CamelJmsBindingModel extends CamelBindingModel {
      * @return a reference to this Camel binding model
      */
     CamelJmsBindingModel setTransactionManager(String transactionManager);
+    
+    /**
+     * The JMS acknowledgement mode name to use.
+     * 
+     * @return Acknowledgement Mode Name.
+     */
+    String getAcknowledgementModeName();
+
+    /**
+     * Specifies the JMS acknowledgement mode name to use with endpoint.
+     * One of SESSION_TRANSACTED, CLIENT_ACKNOWLEDGE, AUTO_ACKNOWLEDGE, DUPS_OK_ACKNOWLEDGE
+     * 
+     * @param acknowledgementModeName String describing the JMS acknowledgement mode.
+     * @return a reference to this Camel binding model
+     */
+    CamelJmsBindingModel setAcknowledgementModeName(String acknowledgementModeName);
+    
+    /**
+     * The Integer value of the JMS acknowledgement mode to use.
+     * 
+     * @return Acknowledgement Mode.
+     */
+    Integer getAcknowledgementMode();
+
+    /**
+     * Specifies Integer value of the JMS acknowledgement mode to use with endpoint.
+     * Primarily facilitates vendor specific extensions beyond the standard values
+     * 
+     * @param acknowledgementMode Integer describing the JMS acknowledgement mode.
+     * @return a reference to this Camel binding model
+     */
+    CamelJmsBindingModel setAcknowledgementMode(Integer acknowledgementMode);
 
 }

--- a/camel/camel-jms/src/main/java/org/switchyard/component/camel/jms/model/v1/V1CamelJmsBindingModel.java
+++ b/camel/camel-jms/src/main/java/org/switchyard/component/camel/jms/model/v1/V1CamelJmsBindingModel.java
@@ -56,7 +56,9 @@ public class V1CamelJmsBindingModel extends V1BaseCamelBindingModel
     private static final String TIME_TO_LIVE = "timeToLive";
     private static final String TRANSACTED = "transacted";
     private static final String TRANSACTION_MANAGER = "transactionManager";
-
+    private static final String ACKNOWLEDGEMENTMODE_NAME = "acknowledgementModeName";
+    private static final String ACKNOWLEDGEMENTMODE = "acknowledgementMode";
+    
     /**
      * Create a new CamelJmsBindingModel.
      */
@@ -67,7 +69,7 @@ public class V1CamelJmsBindingModel extends V1BaseCamelBindingModel
             CLIENT_ID, DURABLE_SUBSCRIPTION_NAME, CONCURRENT_CONSUMERS, MAX_CONCURRENT_CONSUMERS,
             DISABLE_REPLY_TO, PRESERVE_MESSAGE_QOS, DELIVERY_PERSISTENT, PRIORITY,
             EXPLICIT_QOS_ENABLED, REPLY_TO, REPLY_TO_TYPE, REQUEST_TIMEOUT, SELECTOR,
-            TIME_TO_LIVE, TRANSACTED, TRANSACTION_MANAGER);
+            TIME_TO_LIVE, TRANSACTED, TRANSACTION_MANAGER, ACKNOWLEDGEMENTMODE_NAME, ACKNOWLEDGEMENTMODE);
     }
 
     /**
@@ -298,6 +300,27 @@ public class V1CamelJmsBindingModel extends V1BaseCamelBindingModel
     @Override
     public V1CamelJmsBindingModel setTransactionManager(String transactionManager) {
         return setConfig(TRANSACTION_MANAGER, transactionManager);
+    }
+    
+    @Override
+    public String getAcknowledgementModeName() {
+        return getConfig(ACKNOWLEDGEMENTMODE_NAME);
+    }
+
+    @Override
+    public V1CamelJmsBindingModel setAcknowledgementModeName(
+            String acknowledgementModeName) {
+        return setConfig(ACKNOWLEDGEMENTMODE_NAME, acknowledgementModeName);
+    }
+
+    @Override
+    public Integer getAcknowledgementMode() {
+        return getIntegerConfig(ACKNOWLEDGEMENTMODE);
+    }
+
+    @Override
+    public V1CamelJmsBindingModel setAcknowledgementMode(Integer acknowledgementMode) {
+        return setConfig(ACKNOWLEDGEMENTMODE, acknowledgementMode);
     }
 
     @Override

--- a/camel/camel-jms/src/test/java/org/switchyard/component/camel/jms/model/v1/V1CamelJmsBindingModelTest.java
+++ b/camel/camel-jms/src/test/java/org/switchyard/component/camel/jms/model/v1/V1CamelJmsBindingModelTest.java
@@ -46,12 +46,14 @@ public class V1CamelJmsBindingModelTest extends V1BaseCamelServiceBindingModelTe
     private static String SELECTOR = "DEST='ESB'";
     private static Integer TIME_TO_LIVE = 3600;
     private static Boolean TRANSACTED = true;
-
+    private static String ACKNOWLEDGEMENTMODE_NAME = "AUTO_ACKNOWLEDGE";
+    private static Integer ACKNOWLEDGEMENTMODE = -1;
+    
     private static final String CAMEL_URI = "jms:topic:esb_in_topic?connectionFactory=connFactory&" +
         "username=camel&password=isMyFriend&clientId=esb_in&durableSubscriptionName=esb_in_sub&" +
         "concurrentConsumers=5&maxConcurrentConsumers=15&disableReplyTo=true&preserveMessageQos=true&" +
         "deliveryPersistent=false&priority=9&explicitQosEnabled=true&replyTo=esb_out&replyToType=Shared&" +
-        "requestTimeout=300&selector=DEST='ESB'&timeToLive=3600&transacted=true";
+        "requestTimeout=300&selector=DEST='ESB'&timeToLive=3600&transacted=true&acknowledgementModeName=AUTO_ACKNOWLEDGE&acknowledgementMode=-1";
 
     public V1CamelJmsBindingModelTest() {
         super(JmsEndpoint.class, CAMEL_XML);
@@ -80,7 +82,9 @@ public class V1CamelJmsBindingModelTest extends V1BaseCamelServiceBindingModelTe
             .setRequestTimeout(REQUEST_TIMEOUT)
             .setSelector(SELECTOR)
             .setTimeToLive(TIME_TO_LIVE)
-            .setTransacted(TRANSACTED);
+            .setTransacted(TRANSACTED)
+            .setAcknowledgementModeName(ACKNOWLEDGEMENTMODE_NAME)
+            .setAcknowledgementMode(ACKNOWLEDGEMENTMODE);
     }
 
     @Override
@@ -104,6 +108,8 @@ public class V1CamelJmsBindingModelTest extends V1BaseCamelServiceBindingModelTe
         assertEquals(SELECTOR, model.getSelector());
         assertEquals(TIME_TO_LIVE, model.getTimeToLive());
         assertEquals(TRANSACTED, model.isTransacted());
+        assertEquals(ACKNOWLEDGEMENTMODE_NAME, model.getAcknowledgementModeName());
+        assertEquals(ACKNOWLEDGEMENTMODE, model.getAcknowledgementMode());
     }
 
     @Override

--- a/camel/camel-jms/src/test/resources/v1/switchyard-jms-binding-beans.xml
+++ b/camel/camel-jms/src/test/resources/v1/switchyard-jms-binding-beans.xml
@@ -38,6 +38,8 @@
                 <jms:selector>DEST='ESB'</jms:selector>
                 <jms:timeToLive>3600</jms:timeToLive>
                 <jms:transacted>true</jms:transacted>
+                <jms:acknowledgementModeName>AUTO_ACKNOWLEDGE</jms:acknowledgementModeName>
+                <jms:acknowledgementMode>-1</jms:acknowledgementMode>
             </jms:binding.jms>
         </sca:service>
     </sca:composite>

--- a/common/camel/src/main/resources/org/switchyard/component/camel/common/model/v1/camel-common-v1.xsd
+++ b/common/camel/src/main/resources/org/switchyard/component/camel/common/model/v1/camel-common-v1.xsd
@@ -148,6 +148,8 @@
             <element name="timeToLive" type="switchyard:propInteger" minOccurs="0" maxOccurs="1"/>
             <element name="transacted" type="boolean" minOccurs="0" maxOccurs="1"/>
             <element name="transactionManager" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="acknowledgementModeName" type="string" minOccurs="0" maxOccurs="1"/>
+            <element name="acknowledgementMode" type="switchyard:propInteger" minOccurs="0" maxOccurs="1"/>
         </sequence>
     </group>
 


### PR DESCRIPTION
Added acknowledgementModeName (SESSION_TRANSACTED, CLIENT_ACKNOWLEDGE, AUTO_ACKNOWLEDGE, DUPS_OK_ACKNOWLEDGE) and an Integer acknowledgementMode (for vendor extensions) as supported by underlying Camel JMS.

Code passed checkstyle and has an updated unit test to prove that acknowlegementModeName and acknowledgementMode are picked up and applied.
