### PR TITLE
SWITCHYARD-1689: Wrong classloader set in FireUntilHalt thread of Rules component

### DIFF
--- a/rules/src/main/java/org/switchyard/component/rules/exchange/RulesExchangeHandler.java
+++ b/rules/src/main/java/org/switchyard/component/rules/exchange/RulesExchangeHandler.java
@@ -132,7 +132,11 @@ public class RulesExchangeHandler extends KnowledgeExchangeHandler<RulesComponen
                 sessionId = session.getId();
                 setGlobals(inputMessage, operation, session);
                 if (_fireUntilHaltThread == null) {
-                    FireUntilHalt fireUntilHalt = new FireUntilHalt(this, session, getLoader());
+                    ClassLoader fireUntilHaltLoader = Classes.getTCCL();
+                    if (fireUntilHaltLoader == null) {
+                        fireUntilHaltLoader = getLoader();
+                    }
+                    FireUntilHalt fireUntilHalt = new FireUntilHalt(this, session, fireUntilHaltLoader);
                     session.addDisposals(fireUntilHalt);
                     _fireUntilHaltThread = fireUntilHalt.startThread();
                 }


### PR DESCRIPTION
SWITCHYARD-1689: Wrong classloader set in FireUntilHalt thread of Rules component
https://issues.jboss.org/browse/SWITCHYARD-1689
