### PR TITLE
SWITCHYARD-1691: Drools channels must specify service reference with component name

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/service/SwitchYardServiceTaskHandler.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/service/SwitchYardServiceTaskHandler.java
@@ -67,9 +67,9 @@ public class SwitchYardServiceTaskHandler implements WorkItemHandler {
     public static final String FAULT_ACTION = FAULT + "Action";
 
     private String _name;
+    private QName _componentName;
     private SwitchYardServiceInvoker _invoker;
     private ProcessRuntime _processRuntime;
-    private QName _componentName;
 
     /**
      * Constructs a new SwitchYardServiceTaskHandler with the name "SwitchYard Service Task".
@@ -156,11 +156,11 @@ public class SwitchYardServiceTaskHandler implements WorkItemHandler {
         }
         // service invocation
         QName serviceName = getServiceName(parameters);
-        if (_componentName != null) {
-            serviceName = ComponentNames.qualify(_componentName, serviceName);
+        if (serviceName != null && _componentName != null) {
+            serviceName = ComponentNames.qualify(_componentName, ComponentNames.unqualify(serviceName));
         }
         String operationName = getOperationName(parameters);
-        SwitchYardServiceRequest request = new SwitchYardServiceRequest(serviceName, operationName, content, parameters);
+        SwitchYardServiceRequest request = new SwitchYardServiceRequest(serviceName, operationName, content);
         SwitchYardServiceResponse response = getInvoker().invoke(request);
         // results (output)
         Map<String, Object> results = workItem.getResults();

--- a/bpm/src/main/java/org/switchyard/component/bpm/util/WorkItemHandlers.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/util/WorkItemHandlers.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.xml.namespace.QName;
+
 import org.jbpm.services.task.wih.AbstractHTWorkItemHandler;
 import org.jbpm.services.task.wih.ExternalTaskEventListener;
 import org.jbpm.services.task.wih.LocalHTWorkItemHandler;
@@ -44,6 +46,7 @@ import org.switchyard.component.bpm.runtime.BPMRuntimeManager;
 import org.switchyard.component.bpm.service.StandardSwitchYardServiceTaskHandler;
 import org.switchyard.component.bpm.service.SwitchYardServiceTaskHandler;
 import org.switchyard.component.common.knowledge.service.SwitchYardServiceInvoker;
+import org.switchyard.config.model.composite.ComponentModel;
 
 /**
  * WorkItemHandler functions.
@@ -77,7 +80,9 @@ public final class WorkItemHandlers {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static void registerWorkItemHandlers(BPMComponentImplementationModel model, ClassLoader loader, ProcessRuntime processRuntime, BPMRuntimeManager runtimeManager, ServiceDomain serviceDomain) {
-        String tns = model.getComponent().getTargetNamespace();
+        ComponentModel componentModel = model.getComponent();
+        QName componentName =  componentModel.getQName();
+        String componentTNS =  componentModel.getTargetNamespace();
         Set<String> registeredNames = new HashSet<String>();
         WorkItemHandlersModel workItemHandlersModel = model.getWorkItemHandlers();
         if (workItemHandlersModel != null) {
@@ -95,8 +100,8 @@ public final class WorkItemHandlers {
                     } else {
                         name = ssth.getName();
                     }
-                    ssth.setComponentName(model.getComponent().getQName());
-                    ssth.setInvoker(new SwitchYardServiceInvoker(serviceDomain, tns));
+                    ssth.setComponentName(componentName);
+                    ssth.setInvoker(new SwitchYardServiceInvoker(serviceDomain, componentTNS));
                     ssth.setProcessRuntime(processRuntime);
                 }
                 if (name == null && workItemHandler instanceof AbstractHTWorkItemHandler) {
@@ -116,8 +121,8 @@ public final class WorkItemHandlers {
                 if (defaultHandler instanceof SwitchYardServiceTaskHandler) {
                     SwitchYardServiceTaskHandler ssth = (SwitchYardServiceTaskHandler)defaultHandler;
                     ssth.setName(name);
-                    ssth.setComponentName(model.getComponent().getQName());
-                    ssth.setInvoker(new SwitchYardServiceInvoker(serviceDomain, tns));
+                    ssth.setComponentName(componentName);
+                    ssth.setInvoker(new SwitchYardServiceInvoker(serviceDomain, componentTNS));
                     ssth.setProcessRuntime(processRuntime);
                 }
                 processRuntime.getWorkItemManager().registerWorkItemHandler(name, defaultHandler);

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceChannel.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceChannel.java
@@ -28,10 +28,9 @@ public class SwitchYardServiceChannel implements Channel {
     public static final String SERVICE = "service";
 
     private String _name;
-    private SwitchYardServiceInvoker _invoker;
     private QName _serviceName;
     private String _operationName;
-    private QName _componentName;
+    private SwitchYardServiceInvoker _invoker;
 
     /**
      * Constructs a new SwitchYardServiceChannel with the name "service".
@@ -54,38 +53,6 @@ public class SwitchYardServiceChannel implements Channel {
      */
     public void setName(String name) {
         _name = name;
-    }
-
-    /**
-     * Gets the invoker.
-     * @return the invoker
-     */
-    public SwitchYardServiceInvoker getInvoker() {
-        return _invoker;
-    }
-
-    /**
-     * Sets the invoker.
-     * @param invoker the invoker
-     */
-    public void setInvoker(SwitchYardServiceInvoker invoker) {
-        _invoker = invoker;
-    }
-    
-    /**
-     * Set the service component name associated with this invoker.
-     * @param componentName service component name
-     */
-    public void setComponentName(QName componentName) {
-        _componentName = componentName;
-    }
-    
-    /**
-     * Get the service component name associated with this invoker.
-     * @return service component name
-     */
-    public QName getComponentName() {
-        return _componentName;
     }
 
     /**
@@ -118,6 +85,22 @@ public class SwitchYardServiceChannel implements Channel {
      */
     public void setOperationName(String operationName) {
         _operationName = operationName;
+    }
+
+    /**
+     * Gets the invoker.
+     * @return the invoker
+     */
+    public SwitchYardServiceInvoker getInvoker() {
+        return _invoker;
+    }
+
+    /**
+     * Sets the invoker.
+     * @param invoker the invoker
+     */
+    public void setInvoker(SwitchYardServiceInvoker invoker) {
+        _invoker = invoker;
     }
 
     /**

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceInvoker.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceInvoker.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import org.switchyard.Context;
 import org.switchyard.Exchange;
 import org.switchyard.ExchangePattern;
 import org.switchyard.Message;
@@ -109,8 +110,9 @@ public class SwitchYardServiceInvoker {
                 exchangeIn = serviceReference.createExchange(handler);
             }
             Message messageIn = exchangeIn.createMessage();
+            Context contextIn = exchangeIn.getContext(messageIn);
             for (Map.Entry<String,Object> entry : request.getContext().entrySet()) {
-                exchangeIn.getContext(messageIn).setProperty(entry.getKey(), entry.getValue());
+                contextIn.setProperty(entry.getKey(), entry.getValue());
             }
             Object contentIn = request.getContent();
             if (contentIn != null) {

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceRequest.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceRequest.java
@@ -31,13 +31,13 @@ public class SwitchYardServiceRequest {
     private final Map<String, Object> _context = new HashMap<String, Object>();
 
     /**
-     * Constructs a SwitchYardServiceRequest with the specified service name, service operation name, and content.
+     * Constructs a SwitchYardServiceRequest with the specified service name, operation name, and content.
      * @param serviceName the service name
-     * @param serviceOperationName the service operation name
+     * @param operationName the operation name
      * @param content the content
      */
-    public SwitchYardServiceRequest(QName serviceName, String serviceOperationName, Object content) {
-        this(serviceName, serviceOperationName, content, null);
+    public SwitchYardServiceRequest(QName serviceName, String operationName, Object content) {
+        this(serviceName, operationName, content, null);
     }
 
     /**


### PR DESCRIPTION
SWITCHYARD-1691: Drools channels must specify service reference with component name
https://issues.jboss.org/browse/SWITCHYARD-1691
