### PR TITLE
SWITCHYARD-1695 Add dependencies for log4j that are needed for maven 3.1...

### DIFF
--- a/camel/pom.xml
+++ b/camel/pom.xml
@@ -41,6 +41,10 @@
         <module>camel-test</module>
     </modules>
     <dependencies>
+	<dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
         <!-- external dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -90,5 +90,9 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/resteasy/pom.xml
+++ b/resteasy/pom.xml
@@ -39,6 +39,10 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>log4j</groupId>
+	    <artifactId>log4j</artifactId>
+	</dependency>
+        <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-config</artifactId>
         </dependency>

--- a/soap/pom.xml
+++ b/soap/pom.xml
@@ -170,6 +170,10 @@
             <version>7.5.4.v20111024</version>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>


### PR DESCRIPTION
Add dependencies for log4j that are needed for maven 3.1.0 to build components.
