### PR TITLE
SWITCHYARD-1729: Security context is not propagated between service calls

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
+++ b/bean/src/main/java/org/switchyard/component/bean/config/model/BeanSwitchYardScanner.java
@@ -106,7 +106,11 @@ public class BeanSwitchYardScanner implements Scanner<SwitchYardModel> {
             Requires requires = serviceClass.getAnnotation(Requires.class);
             if (requires != null) {
                 for (SecurityPolicy secPolicy : requires.security()) {
-                    if (secPolicy.supports(PolicyType.INTERACTION)) {
+                    if (secPolicy == SecurityPolicy.AUTHORIZATION) {
+                        // authorization supports both interaction and implementation,
+                        // and we want to add it as implementation to be more correct.
+                        beanModel.addPolicyRequirement(secPolicy.getName());
+                    } else if (secPolicy.supports(PolicyType.INTERACTION)) {
                         serviceModel.addPolicyRequirement(secPolicy.getName());
                     } else if (secPolicy.supports(PolicyType.IMPLEMENTATION)) {
                         beanModel.addPolicyRequirement(secPolicy.getName());

--- a/bean/src/test/java/org/switchyard/component/bean/tests/RequiredPoliciesTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/RequiredPoliciesTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.config.model.ScannerInput;
+import org.switchyard.config.model.composite.ComponentImplementationModel;
 import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.config.model.composite.ComponentReferenceModel;
 import org.switchyard.config.model.composite.ComponentServiceModel;
@@ -62,8 +63,9 @@ public class RequiredPoliciesTest {
         
         for(ComponentModel component : components) {
             if(component.getName().equals("SecureService")) {
+                ComponentImplementationModel impl = component.getImplementation();
+                Assert.assertTrue(impl.hasPolicyRequirement(SecurityPolicy.AUTHORIZATION.getName()));
                 ComponentServiceModel svc = component.getServices().get(0);
-                Assert.assertTrue(svc.hasPolicyRequirement(SecurityPolicy.AUTHORIZATION.getName()));
                 Assert.assertTrue(svc.hasPolicyRequirement(SecurityPolicy.CLIENT_AUTHENTICATION.getName()));
                 Assert.assertTrue(svc.hasPolicyRequirement(SecurityPolicy.CONFIDENTIALITY.getName()));
                 ComponentReferenceModel ref = component.getReferences().get(0);

--- a/bean/src/test/java/org/switchyard/component/bean/tests/ServiceAnnotationTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/ServiceAnnotationTest.java
@@ -16,7 +16,6 @@ package org.switchyard.component.bean.tests;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,12 +23,8 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.switchyard.common.type.Classes;
-import org.switchyard.component.bean.Service;
-import org.switchyard.component.bean.config.model.BeanComponentImplementationModel;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.config.model.ScannerInput;
-import org.switchyard.config.model.composite.ComponentImplementationModel;
 import org.switchyard.config.model.composite.ComponentModel;
 import org.switchyard.config.model.switchyard.SwitchYardModel;
 

--- a/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
+++ b/camel/camel-switchyard/src/main/java/org/switchyard/component/camel/SwitchYardProducer.java
@@ -27,6 +27,7 @@ import org.switchyard.Message;
 import org.switchyard.Scope;
 import org.switchyard.ServiceDomain;
 import org.switchyard.ServiceReference;
+import org.switchyard.SwitchYardException;
 import org.switchyard.common.camel.SwitchYardCamelContext;
 import org.switchyard.component.camel.common.CamelConstants;
 import org.switchyard.component.camel.common.composer.BindingDataCreator;
@@ -34,13 +35,12 @@ import org.switchyard.component.camel.common.composer.BindingDataCreatorResolver
 import org.switchyard.component.camel.common.composer.CamelBindingData;
 import org.switchyard.component.common.composer.MessageComposer;
 import org.switchyard.component.common.composer.SecurityBindingData;
-import org.switchyard.SwitchYardException;
 import org.switchyard.label.BehaviorLabel;
 import org.switchyard.metadata.ServiceOperation;
 import org.switchyard.policy.PolicyUtil;
 import org.switchyard.policy.TransactionPolicy;
 import org.switchyard.runtime.event.ExchangeCompletionEvent;
-import org.switchyard.security.SecurityContext;
+import org.switchyard.security.context.SecurityContextManager;
 import org.switchyard.selector.OperationSelector;
 
 /**
@@ -117,8 +117,9 @@ public class SwitchYardProducer extends DefaultProducer {
         CamelBindingData bindingData = bindingCreator.createBindingData(camelExchange.getIn());
         if (bindingData instanceof SecurityBindingData) {
             // returned binding is contains some security bindings, let's move them to security context
-            SecurityContext.get(switchyardExchange).getCredentials().addAll(
-                ((SecurityBindingData) bindingData).extractCredentials());
+            ServiceDomain serviceDomain = ((SwitchYardCamelContext)camelExchange.getContext()).getServiceDomain();
+            SecurityContextManager securityContextManager = new SecurityContextManager(serviceDomain);
+            securityContextManager.addCredentials(switchyardExchange, ((SecurityBindingData)bindingData).extractCredentials());
         }
         
         /*

--- a/soap/src/main/java/org/switchyard/component/soap/InboundHandler.java
+++ b/soap/src/main/java/org/switchyard/component/soap/InboundHandler.java
@@ -56,7 +56,8 @@ import org.switchyard.component.soap.util.WSDLUtil;
 import org.switchyard.deploy.BaseServiceHandler;
 import org.switchyard.label.BehaviorLabel;
 import org.switchyard.runtime.event.ExchangeCompletionEvent;
-import org.switchyard.security.SecurityContext;
+import org.switchyard.security.context.SecurityContext;
+import org.switchyard.security.context.SecurityContextManager;
 import org.switchyard.security.credential.Credential;
 import org.w3c.dom.Node;
 
@@ -75,6 +76,7 @@ public class InboundHandler extends BaseServiceHandler {
     private final SOAPBindingModel _config;
     private final String _gatewayName;
     private MessageComposer<SOAPBindingData> _messageComposer;
+    private SecurityContextManager _securityContextManager;
     private ServiceDomain _domain;
     private ServiceReference _service;
     private long _waitTimeout = DEFAULT_TIMEOUT; // default of 15 seconds
@@ -128,6 +130,7 @@ public class InboundHandler extends BaseServiceHandler {
         _config = config;
         _gatewayName = config.getName();
         _domain = domain;
+        _securityContextManager = new SecurityContextManager(_domain);
     }
 
     /**
@@ -288,9 +291,10 @@ public class InboundHandler extends BaseServiceHandler {
             SOAPBindingData soapBindingData = new SOAPBindingData(soapMessage, wsContext);
 
             // add any thread-local and/or binding-extracted credentials
-            SecurityContext securityContext = SecurityContext.get(exchange);
+            SecurityContext securityContext = _securityContextManager.getContext(exchange);
             securityContext.getCredentials().addAll(credentials);
             securityContext.getCredentials().addAll(soapBindingData.extractCredentials());
+            _securityContextManager.setContext(exchange, securityContext);
 
             Message message;
             try {


### PR DESCRIPTION
SWITCHYARD-1729: Security context is not propagated between service calls
https://issues.jboss.org/browse/SWITCHYARD-1729
