### PR TITLE
SWITCHYARD-1778: Upgrade KIE/Drools/jBPM from 6.0.0.CR3 to 6.0.0.CR5

### DIFF
--- a/bpm/pom.xml
+++ b/bpm/pom.xml
@@ -68,10 +68,6 @@
         </dependency>
         <dependency>
             <groupId>org.jbpm</groupId>
-            <artifactId>jbpm-form-services</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jbpm</groupId>
             <artifactId>jbpm-human-task-core</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
SWITCHYARD-1778: Upgrade KIE/Drools/jBPM from 6.0.0.CR3 to 6.0.0.CR5
https://issues.jboss.org/browse/SWITCHYARD-1778
