### PR TITLE
SWITCHYARD-366 Not doing autoboxing for primitive types

### DIFF
--- a/bean/src/main/java/org/switchyard/component/bean/DefaultBeanPrimitiveTransformer.java
+++ b/bean/src/main/java/org/switchyard/component/bean/DefaultBeanPrimitiveTransformer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.bean;
+
+import javax.inject.Named;
+import org.switchyard.annotations.Transformer;
+
+/**
+ * Transformer to go from Character -> char.
+ */
+@Named("DefaultBeanPrimitiveTransformer") 
+public class DefaultBeanPrimitiveTransformer {
+    /**
+     * Transform from Character -> char.
+     * @param from from
+     * @return char
+     */
+    @Transformer(from = "java:java.lang.Character")
+    public char transform(Character from) {
+        char c = (char) from.charValue();
+        return c;
+    }
+}

--- a/bean/src/main/java/org/switchyard/component/bean/Invocation.java
+++ b/bean/src/main/java/org/switchyard/component/bean/Invocation.java
@@ -16,6 +16,7 @@ package org.switchyard.component.bean;
 
 import org.switchyard.Exchange;
 import org.switchyard.Message;
+import org.switchyard.common.camel.PrimitiveUnboxingUtil;
 
 import java.lang.reflect.Method;
 
@@ -110,7 +111,8 @@ public class Invocation {
             if (_args[0] != null) {
                 Class<?> argType = _method.getParameterTypes()[0];
 
-                if (!argType.isInstance(_args[0])) {
+                if ((!argType.isInstance(_args[0]))
+                    && (!PrimitiveUnboxingUtil.isUnboxingException(argType, _args[0]))) {
                     throw BeanMessages.MESSAGES.beanServiceOperationRequiresAPayloadTypeOf(operationName(), argType.getName(), _args[0].getClass().getName());
                 }
             }

--- a/bean/src/main/resources/META-INF/switchyard/transforms.xml
+++ b/bean/src/main/resources/META-INF/switchyard/transforms.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ - Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+<transforms xmlns="urn:switchyard-config:switchyard:1.0"
+            xmlns:trfm="urn:switchyard-config:transform:1.0">
+            
+            <!--
+                         to="{http://schemas.xmlsoap.org/soap/envelope/}Fault"
+                         -->
+
+    <!-- Default Exception to SOAP Fault transformer... -->
+    <trfm:transform.java from="java:java.lang.Character"
+                         to="java:char"
+                         class="org.switchyard.component.bean.DefaultBeanPrimitiveTransformer"/>
+
+</transforms>

--- a/bean/src/test/java/org/switchyard/component/bean/tests/UnboxService.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/UnboxService.java
@@ -1,0 +1,12 @@
+package org.switchyard.component.bean.tests;
+
+public interface UnboxService {
+	public boolean unboxBoolean(boolean boolValue);
+	public byte unboxByte(byte byteValue);
+	public char unboxChar(char charValue);
+	public double unboxDouble(double doubleValue);
+	public float unboxFloat(float floatValue);
+	public int unboxInt(int intValue);
+	public long unboxLong(long longValue);
+	public short unboxShort(short shortValue);
+}

--- a/bean/src/test/java/org/switchyard/component/bean/tests/UnboxServiceBean.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/UnboxServiceBean.java
@@ -1,0 +1,48 @@
+package org.switchyard.component.bean.tests;
+
+import org.switchyard.component.bean.Service;
+
+@Service(UnboxService.class)
+public class UnboxServiceBean implements UnboxService {
+
+	@Override
+	public boolean unboxBoolean(boolean boolValue) {
+		return boolValue;
+	}
+
+	@Override
+	public byte unboxByte(byte byteValue) {
+		return byteValue;
+	}
+
+	@Override
+	public char unboxChar(char charValue) {
+		return charValue;
+	}
+
+	@Override
+	public double unboxDouble(double doubleValue) {
+		return doubleValue;
+	}
+
+	@Override
+	public float unboxFloat(float floatValue) {
+		return floatValue;
+	}
+
+	@Override
+	public int unboxInt(int intValue) {
+		return intValue;
+	}
+
+	@Override
+	public long unboxLong(long longValue) {
+		return longValue;
+	}
+
+	@Override
+	public short unboxShort(short shortValue) {
+		return shortValue;
+	}
+
+}

--- a/bean/src/test/java/org/switchyard/component/bean/tests/UnboxTest.java
+++ b/bean/src/test/java/org/switchyard/component/bean/tests/UnboxTest.java
@@ -1,0 +1,98 @@
+package org.switchyard.component.bean.tests;
+import org.junit.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.Message;
+
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+/*
+ * Assorted methods for testing a CDI bean consuming a service in SwitchYard.
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
+public class UnboxTest {
+    @ServiceOperation("UnboxService.unboxBoolean")
+    private Invoker unboxBoolean;
+    
+    @ServiceOperation("UnboxService.unboxByte")
+    private Invoker unboxByte;
+    
+    @ServiceOperation("UnboxService.unboxChar")
+    private Invoker unboxChar;
+        
+    @ServiceOperation("UnboxService.unboxDouble")
+    private Invoker unboxDouble;
+
+    @ServiceOperation("UnboxService.unboxFloat")
+    private Invoker unboxFloat;
+
+    @ServiceOperation("UnboxService.unboxInt")
+    private Invoker unboxInt;
+
+    @ServiceOperation("UnboxService.unboxLong")
+    private Invoker unboxLong;
+
+    @ServiceOperation("UnboxService.unboxShort")
+    private Invoker unboxShort;
+    
+    @Test
+    public void unboxBooleanTest() {
+    	 Message response = unboxBoolean.sendInOut(true);
+    	Assert.assertEquals(true, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxByte() {
+    	byte c = 100;
+    	Message response = unboxByte.sendInOut(c);
+    	Assert.assertEquals(c, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxChar() {
+    	char b = 'c';
+    	Message response = unboxChar.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxDouble() {
+    	double b = 1;
+    	Message response = unboxDouble.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxFloat() {
+    	float b = 100;
+    	Message response = unboxFloat.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxInt() {
+    	int b = 100;
+    	 Message response = unboxInt.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+    
+    @Test
+    public void unboxLongTest() {
+    	long b = 100;
+    	 Message response = unboxLong.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+    
+    @Test
+    public void testUnboxShort() {
+    	short b = 100;
+    	 Message response = unboxShort.sendInOut(b);
+    	Assert.assertEquals(b, response.getContent());
+    }
+
+}


### PR DESCRIPTION
Check to make sure in Invocation.java that we provide an exception for unboxing when we test whether the types match the method.     Most of the primitive types are handled by Camel type converters in core CamelMessage.getBody().     For some reason, Character->char conversions are not handled there, so adding a default transformation for that.     

If we want to provide transformations for all the primitive types, I can go ahead and resubmit with the added transformations.     As long as a transformation is provided, CamelMessage.getBody() will use that path.
