### PR TITLE
SWITCHYARD-1826: SwitchYardServiceInvoker hides invocation errors for one-way services

### DIFF
--- a/bpm/src/main/java/org/switchyard/component/bpm/BPMLogger.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/BPMLogger.java
@@ -19,14 +19,6 @@ public interface BPMLogger {
     BPMLogger ROOT_LOGGER = Logger.getMessageLogger(BPMLogger.class, BPMLogger.class.getPackage().getName());
 
     /**
-     * emsg method definition.
-     * @param emsg the emsg
-     */
-    @LogMessage(level = Level.ERROR)
-    @Message(id = 31600, value = "%s")
-    void formattedFaultMessage(String emsg);
-
-    /**
      * null method definition.
      * @param faultAction the faultAction
      * @param fa the fa

--- a/bpm/src/main/java/org/switchyard/component/bpm/BPMMessages.java
+++ b/bpm/src/main/java/org/switchyard/component/bpm/BPMMessages.java
@@ -1,11 +1,13 @@
 package org.switchyard.component.bpm;
 
 import java.io.IOException;
+
 import javax.transaction.HeuristicMixedException;
 import javax.transaction.HeuristicRollbackException;
 import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
+
 import org.jboss.logging.Cause;
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Message;
@@ -159,13 +161,5 @@ public interface BPMMessages {
      */
     @Message(id = 32017, value = "Could not instantiate workItemHandler class: %s")
     SwitchYardException couldNotInstantiateWorkItemHandlerClass(String workItemHandlerClassName);
-
-    
-    /**
-     * faultEncountered method definition.
-     * @return String
-     */
-    @Message(id = 32018, value = "Fault encountered")
-    String faultEncountered();
 }
 

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/CommonKnowledgeLogger.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/CommonKnowledgeLogger.java
@@ -68,5 +68,12 @@ public interface CommonKnowledgeLogger {
     void problemDisposingKnowledgeAgent(String tMessage);
     */
 
+    /**
+     * emsg method definition.
+     * @param emsg the emsg
+     */
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 34606, value = "%s")
+    void formattedFaultMessage(String emsg);
 }
 

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/CommonKnowledgeMessages.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/CommonKnowledgeMessages.java
@@ -105,5 +105,12 @@ public interface CommonKnowledgeMessages {
      */
     @Message(id = 34712, value = "Problem building knowledge")
     String problemBuildingKnowledge();
+
+    /**
+     * faultEncountered method definition.
+     * @return String
+     */
+    @Message(id = 34713, value = "Fault encountered")
+    String faultEncountered();
 }
 

--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceChannel.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/service/SwitchYardServiceChannel.java
@@ -108,7 +108,11 @@ public class SwitchYardServiceChannel implements Channel {
      */
     @Override
     public void send(Object object) {
-        getInvoker().invoke(new SwitchYardServiceRequest(getServiceName(), getOperationName(), object));
+        SwitchYardServiceRequest request = new SwitchYardServiceRequest(getServiceName(), getOperationName(), object);
+        SwitchYardServiceResponse response = getInvoker().invoke(request);
+        if (response.hasFault()) {
+            response.logFaultMessage();
+        }
     }
 
 }


### PR DESCRIPTION
SWITCHYARD-1826: SwitchYardServiceInvoker hides invocation errors for one-way services
https://issues.jboss.org/browse/SWITCHYARD-1826
