### PR TITLE
SWITCHYARD-1885 shrinkwrap-impl-base dependency is missing for JCAMixIn

### DIFF
--- a/jca/pom.xml
+++ b/jca/pom.xml
@@ -39,6 +39,34 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>skipJCAMixInTests</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/JCACCIServiceBindingTest*.java</exclude>
+                                <exclude>**/JCACCIReferenceBindingTest*.java</exclude>
+                                <exclude>**/JCACCIStreamReferenceBindingTest*.java</exclude>
+                                <exclude>**/JCAJMSServiceBindingTest*.java</exclude>
+                                <exclude>**/JCAJMSReferenceBindingTest*.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>runJCAMixInTests</id>
+        </profile>
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>org.switchyard</groupId>

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIReferenceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIReferenceBindingTest.java
@@ -22,7 +22,6 @@ import javax.resource.cci.MappedRecord;
 import javax.resource.cci.Record;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
@@ -43,7 +42,6 @@ import org.switchyard.test.SwitchYardTestCaseConfig;
  * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
  *
  */
-@Ignore
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = "switchyard-outbound-cci-test.xml", mixins = {JCAMixIn.class, CDIMixIn.class})
 public class JCACCIReferenceBindingTest  {

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIServiceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIServiceBindingTest.java
@@ -18,7 +18,6 @@ import javax.resource.cci.Record;
 import javax.resource.cci.RecordFactory;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
@@ -38,7 +37,6 @@ import org.switchyard.test.SwitchYardTestKit;
  * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
  *
  */
-@Ignore
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = "switchyard-inbound-cci-test.xml", mixins = {JCAMixIn.class, CDIMixIn.class})
 public class JCACCIServiceBindingTest  {

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCACCIStreamReferenceBindingTest.java
@@ -22,7 +22,6 @@ import javax.resource.cci.InteractionSpec;
 import javax.resource.cci.Record;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.jca.processor.cci.StreamableRecord;
@@ -45,7 +44,6 @@ import org.switchyard.test.SwitchYardTestCaseConfig;
  * @author Antti Laisi
  *
  */
-@Ignore
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = "switchyard-outbound-cci-stream-test.xml", mixins = {JCAMixIn.class, CDIMixIn.class})
 public class JCACCIStreamReferenceBindingTest {

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCAJMSReferenceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCAJMSReferenceBindingTest.java
@@ -19,7 +19,6 @@ import javax.transaction.UserTransaction;
 
 import junit.framework.Assert;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
@@ -38,7 +37,6 @@ import org.switchyard.test.SwitchYardTestCaseConfig;
  * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
  *
  */
-@Ignore
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = "switchyard-outbound-jms-test.xml", mixins = {HornetQMixIn.class, JCAMixIn.class, CDIMixIn.class})
 public class JCAJMSReferenceBindingTest  {

--- a/jca/src/test/java/org/switchyard/component/jca/deploy/JCAJMSServiceBindingTest.java
+++ b/jca/src/test/java/org/switchyard/component/jca/deploy/JCAJMSServiceBindingTest.java
@@ -17,7 +17,6 @@ import javax.jms.MessageProducer;
 import javax.jms.TextMessage;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.Context;
@@ -42,7 +41,6 @@ import org.switchyard.test.SwitchYardTestKit;
  * @author <a href="mailto:tm.igarashi@gmail.com">Tomohisa Igarashi</a>
  *
  */
-@Ignore
 @RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = "switchyard-inbound-jms-test.xml", mixins = {JCAMixIn.class, HornetQMixIn.class, CDIMixIn.class})
 public class JCAJMSServiceBindingTest  {

--- a/test/mixins/jca/pom.xml
+++ b/test/mixins/jca/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>shrinkwrap-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-api-base</artifactId>
         </dependency>


### PR DESCRIPTION
now -PrunJCAMixInTests maven option enables testcases which are using deprecated JCAMixIn
