### PR TITLE
SWITCHYARD-2175 Atom bound service throws errors

### DIFF
--- a/camel/camel-atom/src/main/java/org/switchyard/component/camel/atom/transformer/AtomTransforms.java
+++ b/camel/camel-atom/src/main/java/org/switchyard/component/camel/atom/transformer/AtomTransforms.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.camel.atom.transformer;
+
+import org.apache.abdera.parser.stax.FOMEntry;
+
+import org.switchyard.annotations.Transformer;
+
+/**
+ * Provide a default transformer from org.apache.abdera.parser.stax.FOMEntry->String,
+ * which is useful for creating a simple service using the Camel Atom binding.
+ * 
+ * @author tcunning
+ */
+public class AtomTransforms {
+    
+    /**
+     * Singleton instance.
+     */
+    public static final AtomTransforms TRANSFORMER = new AtomTransforms();
+    
+    /**
+     * Transform FOMEntry->String.
+     * @param entry entry
+     * @return String
+     */
+    @Transformer
+    public String toString(FOMEntry entry) {
+        return entry.toString();
+    }
+
+}

--- a/camel/camel-atom/src/main/resources/META-INF/switchyard/transforms.xml
+++ b/camel/camel-atom/src/main/resources/META-INF/switchyard/transforms.xml
@@ -1,0 +1,3 @@
+<transforms xmlns="urn:switchyard-config:switchyard:1.1">
+    <transform.java xmlns="urn:switchyard-config:transform:1.1" class="org.switchyard.component.camel.atom.transformer.AtomTransforms" from="java:org.apache.abdera.parser.stax.FOMEntry" to="java:java.lang.String"/>
+</transforms>


### PR DESCRIPTION
Add a default transformation for Abdera FOMEntry -> String for simple Atom binding services.
