### PR TITLE
SWITCHYARD-2262 transaction bridging should not be attempted in Karaf

### DIFF
--- a/sca/src/main/java/org/switchyard/component/sca/NOPEndpointPublisher.java
+++ b/sca/src/main/java/org/switchyard/component/sca/NOPEndpointPublisher.java
@@ -53,4 +53,15 @@ public class NOPEndpointPublisher implements RemoteEndpointPublisher {
         return null;
     }
 
+    @Override
+    public RemoteEndpointPublisher setDisableRemoteTransaction(
+            boolean _bridgeRemoteTransaction) {
+        return this;
+    }
+
+    @Override
+    public boolean isDisableRemoteTransaction() {
+        return false;
+    }
+
 }

--- a/sca/src/main/java/org/switchyard/component/sca/RemoteEndpointPublisher.java
+++ b/sca/src/main/java/org/switchyard/component/sca/RemoteEndpointPublisher.java
@@ -72,4 +72,17 @@ public interface RemoteEndpointPublisher {
      * @return endpoint URL as a string
      */
     String getAddress();
+    
+    /**
+     * Set if remote transaction bridging should be disabled.
+     * @param _disableRemoteTransaction true if it disables remote transaction
+     * @return this RemoteEndpointPublisher instance (useful for method chaining)
+     */
+    RemoteEndpointPublisher setDisableRemoteTransaction(boolean _disableRemoteTransaction);
+    
+    /**
+     * Get if remote transaction bridging should be disabled.
+     * @return true if it disables remote transaction
+     */
+    boolean isDisableRemoteTransaction();
 }

--- a/sca/src/main/java/org/switchyard/component/sca/SCALogger.java
+++ b/sca/src/main/java/org/switchyard/component/sca/SCALogger.java
@@ -59,5 +59,12 @@ public interface SCALogger {
     @Message(id = 39204, value = "Cannot enable clustered SCA binding for %s.  No distributed cache is avaialble.")
     void cannotEnableClusteredSCABindingFor(String serviceName);
 
+    /**
+     * ignoringReceivedTransactionContext method definition.
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 39205, value = "Transaction context was received through remote SCA invocation, but remote transaction bridging is disabled on this node. Ignoring.")
+    void ignoringReceivedTransactionContext();
+
 }
 

--- a/sca/src/main/java/org/switchyard/component/sca/SwitchYardRemotingServlet.java
+++ b/sca/src/main/java/org/switchyard/component/sca/SwitchYardRemotingServlet.java
@@ -156,6 +156,11 @@ public class SwitchYardRemotingServlet extends HttpServlet {
                     _log.debug("Transaction context is found in request message: " + txContextHeader);
                 }
                 
+                if (_endpointPublisher.isDisableRemoteTransaction()) {
+                    SCALogger.ROOT_LOGGER.ignoringReceivedTransactionContext();
+                    return false;
+                }
+                
                 ClassLoader origCl = Thread.currentThread().getContextClassLoader();
                 CoordinationContextType cc = null;
                 try {

--- a/sca/src/main/resources/sca.properties
+++ b/sca/src/main/resources/sca.properties
@@ -8,6 +8,9 @@ cache-name = switchyard
 # Name of the configuration file used to configure Infinispan
 cache-config = infinispan-switchyard.xml
 
+# Disable remote transaction bridging (which is not available on karaf)
+disable-remote-transaction = true
+
 # Optional settings to override the generated URL for the remote endpoint
 # used for clustering communication with this instance.  If you have a 
 # clustered setup over multiple hosts, you will need to set this to the 


### PR DESCRIPTION
Added "bridge-remote-transaction" flag as a sca component property to set if transaction should be propagated through the remote SCA invocation.
