### PR TITLE
SWITCHYARD-2261 infinispan not configurable for end users

### DIFF
--- a/sca/pom.xml
+++ b/sca/pom.xml
@@ -94,6 +94,11 @@
                                     <type>properties</type>
                                     <classifier>sca</classifier>
                                 </artifact>
+                                <artifact>
+                                    <file>target/classes/infinispan-switchyard.xml</file>
+                                    <type>xml</type>
+                                    <classifier>infinispan-switchyard</classifier>
+                                </artifact>
                             </artifacts>
                         </configuration>
                     </execution>

--- a/sca/src/main/java/org/switchyard/component/sca/deploy/SCAActivator.java
+++ b/sca/src/main/java/org/switchyard/component/sca/deploy/SCAActivator.java
@@ -13,12 +13,16 @@
  */
 package org.switchyard.component.sca.deploy;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.InputStream;
 
 import javax.naming.InitialContext;
 import javax.xml.namespace.QName;
 
 import org.infinispan.Cache;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.logging.Logger;
@@ -44,6 +48,7 @@ public class SCAActivator extends BaseActivator {
     private static final String CACHE_CONTAINER_ROOT = "java:jboss/infinispan/container/";
     private static final String CACHE_NAME_PROPERTY = "cache-name";
     private static final String CACHE_CONFIG_PROPERTY = "cache-config";
+    private static final String JGROUPS_CONFIG_PROPERTY = "jgroups-config";
     static final String[] TYPES = new String[] {"sca"};
 
     private static Logger _log = Logger.getLogger(SCAActivator.class);
@@ -70,7 +75,8 @@ public class SCAActivator extends BaseActivator {
         // cache manager and try to resolve the cache.
         Configuration cacheFileConfig = environment.getFirstChild(CACHE_CONFIG_PROPERTY);
         if (cacheFileConfig != null && cacheFileConfig.getValue() != null) {
-            createCache(cacheFileConfig.getValue(), cacheName);
+            Configuration jgroupsConfig = environment.getFirstChild(JGROUPS_CONFIG_PROPERTY);
+            createCache(cacheFileConfig.getValue(), cacheName, jgroupsConfig != null ? jgroupsConfig.getValue() : null);
         } else {
             lookupCache(cacheName);
         }
@@ -125,12 +131,27 @@ public class SCAActivator extends BaseActivator {
         return _endpointPublisher;
     }
     
-    private void createCache(String cacheConfig, String cacheName) {
+    private void createCache(String cacheConfig, String cacheName, String jgroupsConfig) {
         ClassLoader origCl = Thread.currentThread().getContextClassLoader();
         try {
-            InputStream configStream = SCAActivator.class.getClassLoader().getResourceAsStream(cacheConfig);
-            Thread.currentThread().setContextClassLoader(DefaultCacheManager.class.getClassLoader());
-            _cache = new DefaultCacheManager(configStream).getCache(cacheName);
+            InputStream configStream = null;
+            File f = new File(cacheConfig);
+            if (f.exists() && f.isFile()) {
+                configStream = new FileInputStream(f);
+            } else {
+                configStream = SCAActivator.class.getClassLoader().getResourceAsStream(cacheConfig);
+            }
+
+            ClassLoader cacheClassLoader = DefaultCacheManager.class.getClassLoader();
+            Thread.currentThread().setContextClassLoader(cacheClassLoader);
+            ConfigurationBuilderHolder holder = new ParserRegistry(cacheClassLoader).parse(configStream);
+            if (jgroupsConfig != null) {
+                holder.getGlobalConfigurationBuilder()
+                      .transport()
+                      .defaultTransport()
+                      .addProperty("configurationFile", jgroupsConfig);
+            }
+            _cache = new DefaultCacheManager(holder, true).getCache(cacheName);
         } catch (Exception ex) {
             _log.debug("Failed to create cache for distributed registry", ex);
         } finally {

--- a/sca/src/main/resources/sca.properties
+++ b/sca/src/main/resources/sca.properties
@@ -6,7 +6,12 @@
 cache-name = switchyard
 
 # Name of the configuration file used to configure Infinispan
-cache-config = infinispan-switchyard.xml
+cache-config = ${karaf.base}/etc/infinispan-switchyard.xml
+
+# Name of the JGroups configuration file which is used by Infinispan
+# jgroups-udp.xml in the infinispan jar is used by default. Uncomment
+# this and place the file when you need to change JGroups settings.
+# jgroups-config = ${karaf.base}/etc/jgroups-udp-switchyard.xml
 
 # Optional settings to override the generated URL for the remote endpoint
 # used for clustering communication with this instance.  If you have a 


### PR DESCRIPTION
Made infinispan XML and JGroups XML configurable for karaf

Verified the infinispan/jgroups XML config file is placed into karaf etc directory, and it's actually loaded (cache initialization fails if I added wrong element into those XMLs)
