### PR TITLE
SWITCHYARD-2015 Unify a type of name for JMS destination

### DIFF
--- a/jca/src/main/java/org/switchyard/component/jca/JCALogger.java
+++ b/jca/src/main/java/org/switchyard/component/jca/JCALogger.java
@@ -131,5 +131,14 @@ public interface JCALogger {
     @Message(id = 36812, value = "Failed to send a message to '%s': %s")
     void failedToSendMessage(String destination, String eMessage);
 
+    /**
+     * invalidDestinationType method definition.
+     * @param type specified destination type
+     * @param alternative alternative destination type
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 36813, value = "Invalid destination type '%s' - using '%s' instead")
+    void invalidDestinationType(String type, String alternative);
+
 }
 

--- a/jca/src/main/java/org/switchyard/component/jca/endpoint/JMSEndpoint.java
+++ b/jca/src/main/java/org/switchyard/component/jca/endpoint/JMSEndpoint.java
@@ -25,6 +25,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.naming.InitialContext;
 
+import org.jboss.logging.Logger;
 import org.switchyard.Context;
 import org.switchyard.Exchange;
 import org.switchyard.ExchangePattern;
@@ -37,6 +38,7 @@ import org.switchyard.component.jca.JCAMessages;
 import org.switchyard.component.jca.composer.JMSBindingData;
 import org.switchyard.SwitchYardException;
 import org.switchyard.selector.OperationSelector;
+
 /**
  * Concrete message endpoint class for JCA message inflow using JMS MessageListener interface.
  * 
@@ -53,6 +55,8 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
     public static final String KEY_DESTINATION_JNDI_PROPERTIES_FILE = "destinationJndiPropertiesFileName";
     /** key for ConnectionFactory JNDI name. */
     public static final String KEY_CONNECTION_FACTORY_JNDI_NAME = "connectionFactoryJndiName";
+    /** key for replyTo/faultTo destination type. */
+    public static final String KEY_DESTINATION_TYPE = "destinationType";
     /** key for replyTo destination name. */
     public static final String KEY_REPLY_TO = "replyTo";
     /** key for faultTo destination name. */
@@ -64,11 +68,13 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
     /** key for password. */
     public static final String KEY_PASSWORD = "password";
 
+    private Logger _logger = Logger.getLogger(JMSEndpoint.class);
     private MessageComposer<JMSBindingData> _composer;
     private OperationSelector<JMSBindingData> _selector;
     private String _jndiPropertiesFileName;
     private String _destinationJndiPropertiesFileName;
     private String _connectionFactoryJNDIName;
+    private DestinationType _defaultDestinationType = DestinationType.JNDI;
     private String _defaultFaultTo;
     private String _defaultReplyTo;
 
@@ -77,9 +83,13 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
     private Properties _jndiProperties;
     private Properties _destinationJndiProperties;
     private ConnectionFactory _connectionFactory;
-    private Destination _faultToJMSDestination;
-    private Destination _replyToJMSDestination;
+    private Destination _defaultFaultToJMSDestination;
+    private Destination _defaultReplyToJMSDestination;
     private MessageType _defaultOutMessageType = MessageType.Object;
+
+    private enum DestinationType {
+        Queue, Topic, JNDI
+    }
 
     private enum MessageType {
         Stream, Map, Text, Object, Bytes, Plain 
@@ -102,31 +112,49 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
                 _connectionFactory = (ConnectionFactory) cfic.lookup(_connectionFactoryJNDIName);
             }
 
-            InitialContext destic = null;
-            if (getDestinationJndiProperties() != null) {
-                cfic.close();
-                destic = new InitialContext(getDestinationJndiProperties());
-            } else {
-                destic = cfic;
-            }
+            // caching replyTo/faultTo destination if its type is JNDI
+            if (_defaultDestinationType == DestinationType.JNDI) {
+                InitialContext destic = null;
+                if (getDestinationJndiProperties() != null) {
+                    cfic.close();
+                    destic = new InitialContext(getDestinationJndiProperties());
+                } else {
+                    destic = cfic;
+                }
 
-            if (_defaultFaultTo != null) {
-                try {
-                    _faultToJMSDestination = (Destination) destic.lookup(_defaultFaultTo);
-                } catch (Exception e) {
-                    JCALogger.ROOT_LOGGER.destinationNotFound(_defaultFaultTo, "faultTo");
+                if (_defaultFaultTo != null) {
+                    try {
+                        _defaultFaultToJMSDestination = (Destination) destic.lookup(_defaultFaultTo);
+                    } catch (Exception e) {
+                        JCALogger.ROOT_LOGGER.destinationNotFound(_defaultFaultTo, "faultTo");
+                    }
                 }
-            }
-            if (_defaultReplyTo != null) {
-                try {
-                    _replyToJMSDestination = (Destination) destic.lookup(_defaultReplyTo);
-                } catch (Exception e) {
-                    JCALogger.ROOT_LOGGER.destinationNotFound(_defaultReplyTo, "replyTo");
+                if (_defaultReplyTo != null) {
+                    try {
+                        _defaultReplyToJMSDestination = (Destination) destic.lookup(_defaultReplyTo);
+                    } catch (Exception e) {
+                        JCALogger.ROOT_LOGGER.destinationNotFound(_defaultReplyTo, "replyTo");
+                    }
                 }
+                destic.close();
             }
-            destic.close();
         } catch (Exception e) {
             throw JCAMessages.MESSAGES.failedToInitialize(this.getClass().getName(), e);
+        }
+        
+        if (_logger.isDebugEnabled()) {
+            StringBuilder msg = new StringBuilder()
+                .append("Initialized with: {")
+                .append("Connection Factory:").append(_connectionFactoryJNDIName)
+                .append(", Destination Type:").append(_defaultDestinationType)
+                .append(", replyTo Name:").append(_defaultReplyTo)
+                .append(", faultTo Name:").append(_defaultReplyTo)
+                .append(", User Name:").append(_userName)
+                .append(", Output Message Type:").append(_defaultOutMessageType)
+                .append(", JNDI Properties File:").append(_jndiPropertiesFileName)
+                .append(", Destination JNDI Properties File:").append(_destinationJndiPropertiesFileName)
+                .append("}");
+            _logger.debug(msg.toString());
         }
     }
 
@@ -140,33 +168,46 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
             Exchange exchange = createExchange(operation, replyHandler);
             exchange.send(_composer.compose(bindingData, exchange));
 
+            if (_connectionFactory == null) {
+                return;
+            }
+            
+            // Process replyTo and faultTo if ConnectionFactory is available 
             Context context = exchange.getContext();
-            Destination faultTo = getFaultToDestination(context);
-            Destination replyTo = getReplyToDestination(context);
-            if (faultTo != null && ExchangeState.FAULT.equals(exchange.getState())) {
-                if (exchange.getMessage() != null) {
-                    sendJMSMessage(faultTo, exchange, getOutputMessageType(context));
+            Connection connection = null;
+            
+            try {
+                if (_userName != null) {
+                    connection = _connectionFactory.createConnection(_userName, _password);
+                } else {
+                    connection = _connectionFactory.createConnection();
                 }
-            } else if (replyTo != null && ExchangePattern.IN_OUT.equals(exchange.getPattern())) {
-                    exchange = replyHandler.waitForOut();
+                Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                
+                Destination faultTo = getFaultToDestinationFromContext(session, context);
+                Destination replyTo = getReplyToDestinationFromContext(session, context);
+                if (faultTo != null && ExchangeState.FAULT.equals(exchange.getState())) {
                     if (exchange.getMessage() != null) {
-                        sendJMSMessage(replyTo, exchange, getOutputMessageType(context));
+                        sendJMSMessage(session, faultTo, exchange, getOutputMessageTypeFromContext(context));
                     }
+                } else if (replyTo != null && ExchangePattern.IN_OUT.equals(exchange.getPattern())) {
+                        exchange = replyHandler.waitForOut();
+                        if (exchange.getMessage() != null) {
+                            sendJMSMessage(session, replyTo, exchange, getOutputMessageTypeFromContext(context));
+                        }
+                }
+            } finally {
+                if (connection != null) {
+                    connection.close();
+                }
             }
         } catch (Exception e) {
             throw new SwitchYardException(e);
         }
     }
 
-    protected void sendJMSMessage(Destination destination, Exchange exchange, MessageType type) {
-        Connection connection = null;
+    protected void sendJMSMessage(Session session, Destination destination, Exchange exchange, MessageType type) {
         try {
-            if (_userName != null) {
-                connection = _connectionFactory.createConnection(_userName, _password);
-            } else {
-                connection = _connectionFactory.createConnection();
-            }
-            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
             MessageProducer producer = session.createProducer(destination);
 
             Message msg;
@@ -192,52 +233,152 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
             producer.send(_composer.decompose(exchange, new JMSBindingData(msg)).getMessage());
         } catch (Exception e) {
             JCALogger.ROOT_LOGGER.failedToSendMessage(destination.toString(), e.getMessage());
-        } finally {
-            if (connection != null) {
-                try {
-                    connection.close();
-                } catch (Exception e) {
-                    JCALogger.ROOT_LOGGER.failedToCloseJMSSessionconnection(e.getMessage());
-                }
+            if (_logger.isDebugEnabled()) {
+                _logger.debug(e);
             }
         }
     }
 
-    protected Destination getReplyToDestination(Context ctx) {
+    protected Destination getReplyToDestinationFromContext(Session session, Context ctx) {
+        Destination replyToDestination = null;
+        
         String key = CONTEXT_PROPERTY_PREFIX + KEY_REPLY_TO;
         if (ctx.getProperty(key) != null) {
-            String destName = ctx.getPropertyValue(key);
+            String replyToName = ctx.getPropertyValue(key);
+            DestinationType replyToType = getDestinationTypeFromContext(ctx);
+            
             try {
-                return getDestinationFromContext(destName);
+                switch (replyToType) {
+                case JNDI:
+                    replyToDestination = lookupDestinationFromJNDI(replyToName);
+                    break;
+                case Queue:
+                    replyToDestination = session.createQueue(replyToName);
+                    break;
+                case Topic:
+                    replyToDestination = session.createTopic(replyToName);
+                    break;
+                }
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug("replyTo is set to '" + replyToName + "'");
+                }
             } catch (Exception e) {
-                if (_defaultReplyTo != null) {
-                    JCALogger.ROOT_LOGGER.contextDestinationNotFound(destName, _defaultReplyTo);
-                } else {
-                    JCALogger.ROOT_LOGGER.destinationNotFound(destName, "replyTo");
+                JCALogger.ROOT_LOGGER.contextDestinationNotFound(replyToName, _defaultReplyTo);
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug(e);
                 }
             }
         }
-        return _replyToJMSDestination;
+        
+        // No valid replyTo is specified in a context property - use default
+        if (replyToDestination == null) {
+            try {
+                switch (_defaultDestinationType) {
+                case JNDI:
+                    replyToDestination = _defaultReplyToJMSDestination;
+                    break;
+                case Queue:
+                    replyToDestination = session.createQueue(_defaultReplyTo);
+                    break;
+                case Topic:
+                    replyToDestination = session.createTopic(_defaultReplyTo);
+                    break;
+                }
+            } catch (Exception e) {
+                JCALogger.ROOT_LOGGER.destinationNotFound(_defaultReplyTo, "replyTo");
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug(e);
+                }
+            }
+        }
+        return replyToDestination;
     }
 
-    protected Destination getFaultToDestination(Context ctx) {
+    protected Destination getFaultToDestinationFromContext(Session session, Context ctx) {
+        Destination faultToDestination = null;
+        
         String key = CONTEXT_PROPERTY_PREFIX + KEY_FAULT_TO;
         if (ctx.getProperty(key) != null) {
-            String destName = ctx.getPropertyValue(key);
+            String faultToName = ctx.getPropertyValue(key);
+            DestinationType faultToType = getDestinationTypeFromContext(ctx);
+            
             try {
-                return getDestinationFromContext(destName);
+                switch (faultToType) {
+                case JNDI:
+                    faultToDestination = lookupDestinationFromJNDI(faultToName);
+                    break;
+                case Queue:
+                    faultToDestination = session.createQueue(faultToName);
+                    break;
+                case Topic:
+                    faultToDestination = session.createTopic(faultToName);
+                    break;
+                }
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug("faultTo is set to '" + faultToName + "'");
+                }
             } catch (Exception e) {
-                if (_defaultFaultTo != null) {
-                    JCALogger.ROOT_LOGGER.contextDestinationNotFound(destName, _defaultFaultTo);
-                } else {
-                    JCALogger.ROOT_LOGGER.destinationNotFound(destName, "faultTo");
+                JCALogger.ROOT_LOGGER.contextDestinationNotFound(faultToName, _defaultFaultTo);
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug(e);
                 }
             }
         }
-        return _faultToJMSDestination;
+        
+        // No valid faultTo is specified in a context property - use default
+        if (faultToDestination == null) {
+            try {
+                switch (_defaultDestinationType) {
+                case JNDI:
+                    faultToDestination = _defaultFaultToJMSDestination;
+                    break;
+                case Queue:
+                    faultToDestination = session.createQueue(_defaultFaultTo);
+                    break;
+                case Topic:
+                    faultToDestination = session.createTopic(_defaultFaultTo);
+                    break;
+                }
+            } catch (Exception e) {
+                JCALogger.ROOT_LOGGER.destinationNotFound(_defaultFaultTo, "faultTo");
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug(e);
+                }
+            }
+        }
+        return faultToDestination;
     }
 
-    protected Destination getDestinationFromContext(String destName) throws Exception {
+    protected DestinationType getDestinationTypeFromContext(Context ctx) {
+        DestinationType destType = _defaultDestinationType;
+        String key = CONTEXT_PROPERTY_PREFIX + KEY_DESTINATION_TYPE;
+        if (ctx.getProperty(key) != null) {
+            String type = ctx.getPropertyValue(key);
+            DestinationType ctxType = parseDestinationType(type);
+            if (ctxType != null) {
+                destType = ctxType;
+                if (_logger.isDebugEnabled()) {
+                    _logger.debug("Destination type is set to '" + destType.toString() + "'");
+                }
+            }
+        }
+        return destType;
+    }
+
+    protected Destination lookupOrCreateDestination(Session session, DestinationType type, String destName) throws Exception {
+        switch (type) {
+        case JNDI:
+            return lookupDestinationFromJNDI(destName);
+        case Queue:
+            return session.createQueue(destName);
+        case Topic:
+            return session.createTopic(destName);
+        default:
+            return null;
+        }
+    }
+
+    protected Destination lookupDestinationFromJNDI(String destName) throws Exception {
         InitialContext ic = null;
         try {
             if (getDestinationJndiProperties() != null) {
@@ -253,16 +394,22 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
                 try {
                     ic.close();
                 } catch (Exception e) {
-                    e.getMessage();
+                    if (_logger.isDebugEnabled()) {
+                        _logger.debug(e);
+                    }
                 }
             }
         }
     }
 
-    protected MessageType getOutputMessageType(Context ctx) {
+    protected MessageType getOutputMessageTypeFromContext(Context ctx) {
         String key = CONTEXT_PROPERTY_PREFIX + KEY_MESSAGE_TYPE;
         if (ctx.getProperty(key) != null) {
-            return MessageType.valueOf(ctx.getPropertyValue(key).toString());
+            MessageType type = MessageType.valueOf(ctx.getPropertyValue(key).toString());
+            if (_logger.isDebugEnabled()) {
+                _logger.debug("Output message type is set to '" + type.toString() + "'");
+            }
+            return type;
         }
         return _defaultOutMessageType;
     }
@@ -274,6 +421,31 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
      */
     public void setConnectionFactoryJNDIName(String name) {
         _connectionFactoryJNDIName = name;
+    }
+
+    /**
+     * Set destination type.
+     * @param type destination type
+     */
+    public void setDestinationType(String type) {
+        DestinationType destType = parseDestinationType(type);
+        if (destType == null) {
+            JCALogger.ROOT_LOGGER.invalidDestinationType(type, DestinationType.JNDI.toString());
+            destType = DestinationType.JNDI;
+        }
+        _defaultDestinationType = destType;
+    }
+
+    protected DestinationType parseDestinationType(String type) {
+        DestinationType destType = null;
+        if (type.equals(javax.jms.Queue.class.getName()) || type.equalsIgnoreCase("queue")) {
+            destType = DestinationType.Queue;
+        } else if (type.equals(javax.jms.Topic.class.getName()) || type.equalsIgnoreCase("Topic")) {
+            destType = DestinationType.Topic;
+        } else if (type.equalsIgnoreCase("JNDI")) {
+            destType = DestinationType.JNDI;
+        }
+        return destType;
     }
 
     /**
@@ -374,3 +546,4 @@ public class JMSEndpoint extends AbstractInflowEndpoint implements MessageListen
         return _destinationJndiProperties;
     }
 }
+

--- a/jca/src/main/java/org/switchyard/component/jca/processor/AbstractOutboundProcessor.java
+++ b/jca/src/main/java/org/switchyard/component/jca/processor/AbstractOutboundProcessor.java
@@ -171,6 +171,14 @@ public abstract class AbstractOutboundProcessor {
     }
     
     /**
+     * get JNDI properties file name.
+     * @return file name
+     */
+    public String getJndiPropertiesFileName() {
+        return _jndiPropertiesFileName;
+    }
+    
+    /**
      * get JNDI properties.
      * @return JNDI properties
      */


### PR DESCRIPTION
Fixed to use physical name for the destination on replyTo/faultTo for inbound and destination for outbound. replyToType, faultType and destinationType has been added to the property.
This includes a fix for "SWITCHYARD-2267 Remove transacted and acknowledgeMode from outbound JCA" as well.
