### PR TITLE
SWITCHYARD-2336 Add the properties to the exchange message

### DIFF
--- a/sca/src/main/java/org/switchyard/component/sca/SwitchYardRemotingServlet.java
+++ b/sca/src/main/java/org/switchyard/component/sca/SwitchYardRemotingServlet.java
@@ -87,7 +87,7 @@ public class SwitchYardRemotingServlet extends HttpServlet {
                     : service.createExchange(msg.getOperation(), replyHandler);
             Message m = ex.createMessage();
             if (msg.getContext() != null) {
-                ex.getContext().setProperties(msg.getContext().getProperties());
+                m.getContext().setProperties(msg.getContext().getProperties());
             }
             m.setContent(msg.getContent());
             


### PR DESCRIPTION
This fixed the problem I was having, but not sure whether this would impact 'exchange' scoped properties. However not sure if there are any such properties coming via the remote invoker.

If this would be an issue, then possibly the exchange and message properties need to be set independently.
