### PR TITLE
SWITCHYARD-2412 Failing WSDLUnitTests on IBM JDK 1.7

### DIFF
--- a/soap/src/test/java/org/switchyard/component/soap/WSDLUtilTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/WSDLUtilTest.java
@@ -64,7 +64,6 @@ public class WSDLUtilTest {
         PortName portName = new PortName("HelloWebServicePortFrench");
         Service service = WSDLUtil.getService("MultiplePortService.wsdl", portName);
         Assert.assertNotNull(service);
-        Assert.assertEquals(service.getQName(), new QName("http://test.ws.other/", "GoodbyeWebService"));
         service = WSDLUtil.getService("MultiplePortService.wsdl", new PortName("HelloWebService:"));
         Assert.assertNotNull(service);
         Assert.assertEquals(service.getQName(), new QName("urn:switchyard-component-soap:test-ws:1.0", "HelloWebService"));
@@ -76,10 +75,8 @@ public class WSDLUtilTest {
     public void nullPortName() throws Exception {
         Service service = WSDLUtil.getService("MultiplePortService.wsdl", new PortName(null));
         Assert.assertNotNull(service);
-        Assert.assertEquals(service.getQName(), new QName("http://test.ws.other/", "GoodbyeWebService"));
         Port port = WSDLUtil.getPort(service, new PortName(null));
         Assert.assertNotNull(port);
-        Assert.assertEquals(port.getName(), "GoodbyeWebServicePort");
         service = WSDLUtil.getService("MultiplePortService.wsdl", new PortName("HelloWebService:"));
         Assert.assertNotNull(service);
         Assert.assertEquals(service.getQName(), new QName("urn:switchyard-component-soap:test-ws:1.0", "HelloWebService"));


### PR DESCRIPTION
Two of the WSDLUnitTests are failing on IBM JDK 1.7 because the order the services are returned from wsdl4j is not guaranteed in the first part of WSDLUtil.getService() - which led to the test failing on an inconsistent basis.   Removed the offending asserts.   
