### PR TITLE
SWITCHYARD-2455 HttpProxyTest should account for apache NoHttpResponseException

### DIFF
--- a/http/src/test/java/org/switchyard/component/http/HttpProxyTest.java
+++ b/http/src/test/java/org/switchyard/component/http/HttpProxyTest.java
@@ -156,7 +156,8 @@ public class HttpProxyTest {
         } catch (Exception e) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             e.printStackTrace(new PrintStream(baos));
-            Assert.assertTrue(baos.toString().contains("UnknownHostException: unreachablehost"));
+            Assert.assertTrue(baos.toString().contains("org.apache.http.NoHttpResponseException: unreachablehost") 
+                    || baos.toString().contains("UnknownHostException: unreachablehost"));
         }
     }
 

--- a/resteasy/src/test/java/org/switchyard/component/resteasy/HttpProxyTest.java
+++ b/resteasy/src/test/java/org/switchyard/component/resteasy/HttpProxyTest.java
@@ -165,7 +165,8 @@ public class HttpProxyTest {
         } catch (Exception e) {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             e.printStackTrace(new PrintStream(baos));
-            Assert.assertTrue(baos.toString().contains("UnknownHostException: unreachablehost"));
+            Assert.assertTrue(baos.toString().contains("org.apache.http.NoHttpResponseException: unreachablehost") 
+                    || baos.toString().contains("UnknownHostException: unreachablehost"));
         }
     }
 


### PR DESCRIPTION
IBM JDK 1.7 on Linux is throwing a different unreachablehost Exception than the one we expect (looks like JDK differences).    Check for the org.apache.http.NoHttpResponseException as well in HttpProxyTest.
