### PR TITLE
SWITCHYARD-2311 BPEL - Timed out after 120000 ms waiting on synchronous response from target service for IN ONLY exchange

### DIFF
--- a/bpel/src/test/java/org/switchyard/component/bpel/riftsaw/BPELInOnlyLocatorTest.java
+++ b/bpel/src/test/java/org/switchyard/component/bpel/riftsaw/BPELInOnlyLocatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.bpel.riftsaw;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.transform.config.model.TransformSwitchYardScanner;
+
+/*
+ * This test is in response to SWITCHYARD-2311.   It uses a modified version
+ * of the loan approval / risk assessment processes which do not return a response,
+ * and triggers the creation of an IN_ONLY exchange in RiftsawServiceLocator. 
+ */
+@SwitchYardTestCaseConfig(
+        config = "/loan2_approval/switchyard.xml",
+        scanners = {TransformSwitchYardScanner.class },
+        mixins = {CDIMixIn.class, HTTPMixIn.class })
+public class BPELInOnlyLocatorTest {
+
+    private SwitchYardTestKit _testKit;
+
+    @org.junit.Before
+    public void init() {
+    	try {
+    		_testKit = new SwitchYardTestKit(this);
+    		_testKit.start();
+    	} catch(Exception e) {
+    		e.printStackTrace();
+    		fail("Unable to initialize testkit: "+ e);
+    	}
+    }
+    
+    @org.junit.After
+    public void close() {
+    	if (_testKit != null) {
+	    	try {
+	    		_testKit.cleanup();
+	    	} catch(Exception e) {
+	    		e.printStackTrace();
+	    		fail("Unable to cleanup testkit: "+ e);
+	    	}
+    	}
+    }
+    
+    @Test
+    public void sendLoanRequest1() throws Exception {
+        String msg = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:exam=\"http://www.jboss.org/bpel/examples/wsdl\">"
+                + "<soapenv:Header/><soapenv:Body>"
+                + "<ns1:request xmlns:ns1=\"http://example.com/loan2-approval/loan2Service/\">"
+                + "<firstName>Fred</firstName>"
+                + "<name>Bloggs</name>"
+                + "<amount>100</amount>"
+                + "</ns1:request>"            
+                + "</soapenv:Body></soapenv:Envelope>";
+       
+        String result = _testKit.getMixIn(HTTPMixIn.class).
+                postResourceAndTestXML("http://localhost:18001/loan2Service",
+                        "/loan2_approval/soap-loanreq1.xml", "/loan2_approval/soap-loanresp1.xml");
+    }
+        
+}

--- a/bpel/src/test/resources/deploy.xml
+++ b/bpel/src/test/resources/deploy.xml
@@ -12,9 +12,13 @@
  - limitations under the License.
  -->
 <deploy xmlns="http://www.apache.org/ode/schemas/dd/2007/03"
+        xmlns:bpl="http://www.jboss.org/bpel/examples"
 	xmlns:ls="http://example.com/loan-approval/loanService/" 
+        xmlns:ls2="http://example.com/loan2-approval/loan2Service/"
 	xmlns:ra="http://example.com/loan-approval/riskAssessment/"
-    xmlns:testDomain="urn:bpel:test:1.0"
+        xmlns:ra2="http://example.com/loan-approval/risk2Assessment/"
+        xmlns:testDomain="urn:bpel:test:1.0"
+        xmlns:intf="http://www.jboss.org/bpel/examples/wsdl"
 	xmlns:examples="http://www.jboss.org/bpel/examples">
 
 	<!-- loan_approval/loanService example -->
@@ -47,5 +51,24 @@
 			<service name="testDomain:SayHelloService" port="ignored"/>
 		</provide>
 	</process>
-	
+
+        <process name="ls2:loan2ApprovalProcess">
+                <active>true</active>
+        <process-events generate="all"/>
+                <provide partnerLink="customer">
+                        <service name="testDomain:loan2Service" port="ignored"/>
+                </provide>
+                <invoke partnerLink="assessor" usePeer2Peer="false">
+                        <service name="testDomain:risk2Assessor" port="ignored"/>
+                </invoke>
+        </process>
+
+        <process name="ra2:risk2AssessmentProcess">
+                <active>true</active>
+        <process-events generate="all"/>
+                <provide partnerLink="assessor">
+                        <service name="testDomain:risk2Assessor" port="ignored"/>
+                </provide>
+        </process>
+
 </deploy>

--- a/bpel/src/test/resources/loan2ServicePT.wsdl
+++ b/bpel/src/test/resources/loan2ServicePT.wsdl
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions targetNamespace="http://example.com/loan2-approval/loan2Service/"
+			xmlns:ens="http://example.com/loan2-approval/xsd/error-messages/"
+			xmlns:plnk="http://docs.oasis-open.org/wsbpel/2.0/plnktype"
+			xmlns:tns="http://example.com/loan2-approval/loan2Service/"
+			xmlns="http://schemas.xmlsoap.org/wsdl/"
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+			
+    <types>
+    
+		<xsd:schema targetNamespace="http://example.com/loan2-approval/xsd/error-messages/">
+		  <xsd:element name="integer" type="xsd:integer" />
+		</xsd:schema>
+
+        <xsd:schema attributeFormDefault="unqualified" elementFormDefault="qualified" 
+                targetNamespace="http://example.com/loan2-approval/loan2Service/" 
+                xmlns="http://www.w3.org/2001/XMLSchema">
+
+	        <element name="request">
+	            <complexType>
+	                <sequence>
+				<element name="firstName" type="xsd:string" />
+				<element name="name" type="xsd:string" />
+				<element name="amount" type="xsd:integer" />
+	                 </sequence>
+	            </complexType>
+	        </element>
+	         
+	        <element name="requestResponse">
+	            <complexType>
+	                <sequence>
+	                    <element name="accept" type="string"/>
+	                 </sequence>
+	            </complexType>
+	        </element>
+	         
+         </xsd:schema>
+	</types>
+	
+	<message name="requestMessage">
+		<part name="parameter" element="tns:request" />
+	</message>
+
+	<message name="requestResponseMessage">
+		<part name="parameter" element="tns:requestResponse" />
+	</message>
+	
+	<message name="errorMessage">
+		<part name="errorCode" element="ens:integer" />
+	</message>
+	
+	<portType name="loan2ServicePT">
+		<operation name="request">
+			<input message="tns:requestMessage" />
+			<output message="tns:requestResponseMessage" />
+			<fault name="unableToHandleRequest"
+					message="tns:errorMessage" />
+		</operation>
+	</portType>
+	
+	<plnk:partnerLinkType name="loan2PartnerLT">
+		<plnk:role name="loan2Service" portType="tns:loan2ServicePT" />
+	</plnk:partnerLinkType>
+	
+    <binding name="loan2Service_Binding" type="tns:loan2ServicePT">
+    	<soap:binding style="document"
+    		transport="http://schemas.xmlsoap.org/soap/http" />
+    	<operation name="request">
+    		<soap:operation
+    			soapAction="http://example.com/loan2-approval/loan2Service/request" />
+    		<input>
+    			<soap:body use="literal" />
+    		</input>
+    		<output>
+    			<soap:body use="literal" />
+    		</output>
+    		<fault name="unableToHandleRequest">
+    			<soap:fault use="literal" name="unableToHandleRequest" />
+    		</fault>
+    	</operation>
+    </binding>
+    
+    <service name="loan2Service">
+    	<port name="loan2Service_Port" binding="tns:loan2Service_Binding">
+    		<soap:address location="http://localhost:8080/Quickstart_bpel_loan2_approvalWS" />
+    	</port>
+    </service>
+    
+</definitions>

--- a/bpel/src/test/resources/loan2_approval.bpel
+++ b/bpel/src/test/resources/loan2_approval.bpel
@@ -1,0 +1,80 @@
+<process name="loan2ApprovalProcess" targetNamespace="http://example.com/loan2-approval/loan2Service/"
+		xmlns="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
+		xmlns:lns="http://example.com/loan2-approval/loan2Service/"
+		xmlns:ans="http://example.com/loan-approval/risk2Assessment/"
+		suppressJoinFailure="yes">
+
+   <import importType="http://schemas.xmlsoap.org/wsdl/" location="loan2ServicePT.wsdl"
+      			namespace="http://example.com/loan2-approval/loan2Service/" />
+   <import importType="http://schemas.xmlsoap.org/wsdl/" location="risk2AssessmentPT.wsdl"
+      			namespace="http://example.com/loan-approval/risk2Assessment/" />
+
+   <partnerLinks>
+      <partnerLink name="customer" partnerLinkType="lns:loan2PartnerLT" myRole="loan2Service" />
+      <partnerLink name="assessor" partnerLinkType="ans:risk2AssessmentLT" partnerRole="assessor" />
+   </partnerLinks>
+
+   <variables>
+      <variable name="request" messageType="lns:requestMessage" />
+      <variable name="requestResponse" messageType="lns:requestResponseMessage" />
+      <variable name="check" messageType="ans:checkMessage" />
+      <variable name="checkResponse" messageType="ans:checkResponseMessage" />
+      <variable name="faultResponse" messageType="lns:errorMessage" />
+   </variables>
+
+   <faultHandlers>
+      <catch faultName="ans:loan2ProcessFault" faultVariable="error"
+						faultMessageType="ans:errorMessage">
+		<sequence>
+	        <assign validate="no" name="CopyFaultValue">
+	            <copy>
+	                <from variable="error" part="errorCode"></from>
+	                <to variable="faultResponse" part="errorCode"></to>
+	            </copy>
+	        </assign>
+	         <reply partnerLink="customer" portType="lns:loan2ServicePT" operation="request" variable="faultResponse"
+	            			faultName="lns:unableToHandleRequest" />
+	     </sequence>
+      </catch>
+   </faultHandlers>
+
+   <sequence>
+      <receive partnerLink="customer" portType="lns:loan2ServicePT"
+				operation="request" variable="request" createInstance="yes" />
+
+        <assign validate="no" name="AssignName">
+            <copy>
+                <from><literal>
+        <check xmlns="http://example.com/loan-approval/risk2Assessment/">
+		   <firstName></firstName>
+		   <name></name>
+		   <amount>1000</amount>
+		</check>
+</literal></from>
+                <to variable="check" part="parameter"></to>
+            </copy>
+            <copy>
+                <from variable="request" part="parameter" query="/request/amount" />
+                <to variable="check" part="parameter" query="/check/amount" />
+            </copy>
+        </assign>
+        
+      <invoke partnerLink="assessor" portType="lns:risk2AssessmentPT" operation="check" 
+	inputVariable="check"/>
+
+
+        <assign validate="no" name="AssignName">
+            <copy>
+                <from><literal><tns:RequestResponse xmlns:tns="http://example.com/loan2-approval/loan2Service/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <tns:accept>yes</tns:accept>
+</tns:RequestResponse>
+</literal></from>
+                <to variable="requestResponse" part="parameter"></to>
+            </copy>
+        </assign>
+
+      <reply partnerLink="customer" portType="lns:loan2ServicePT"
+							operation="request" variable="requestResponse"/>
+   </sequence>
+
+</process>

--- a/bpel/src/test/resources/loan2_approval/soap-loanreq1.xml
+++ b/bpel/src/test/resources/loan2_approval/soap-loanreq1.xml
@@ -1,0 +1,10 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+   <soapenv:Header/>
+   <soapenv:Body>
+		<ns1:request xmlns:ns1="http://example.com/loan2-approval/loan2Service/">
+		   <firstName>Fred</firstName>
+		   <name>Bloggs</name>
+		   <amount>100</amount>
+		</ns1:request>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/bpel/src/test/resources/loan2_approval/soap-loanresp1.xml
+++ b/bpel/src/test/resources/loan2_approval/soap-loanresp1.xml
@@ -1,0 +1,3 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"/><soap:Body><requestResponse xmlns="http://example.com/loan2-approval/loan2Service/">
+  <tns:accept xmlns:tns="http://example.com/loan2-approval/loan2Service/">yes</tns:accept>
+</requestResponse></soap:Body></soap:Envelope>

--- a/bpel/src/test/resources/loan2_approval/switchyard.xml
+++ b/bpel/src/test/resources/loan2_approval/switchyard.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
+             xmlns:swyd="urn:switchyard-config:switchyard:1.0"
+             xmlns:trfm="urn:switchyard-config:transform:1.0"
+             xmlns:bean="urn:switchyard-component-bean:config:1.0"
+             xmlns:soap="urn:switchyard-component-soap:config:1.0"
+             xmlns:bpel="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
+             xmlns:ls="http://example.com/loan2-approval/loan2Service/"
+             xmlns:ra="http://example.com/loan-approval/risk2Assessment/"
+             targetNamespace="urn:bpel:test:1.0"
+             name="loan2approval">
+     <sca:composite name="loan2service" targetNamespace="urn:bpel:test:1.0">
+        <sca:service name="loan2Service" promote="loan2Service">
+            <soap:binding.soap>
+                <soap:wsdl>loan2ServicePT.wsdl</soap:wsdl>
+                <soap:socketAddr>localhost:18001</soap:socketAddr>
+            </soap:binding.soap>
+         </sca:service>
+
+         <sca:component name="loan2Service">
+             <bpel:implementation.bpel process="ls:loan2ApprovalProcess" />
+             <sca:service name="loan2Service">
+                 <sca:interface.wsdl interface="loan2ServicePT.wsdl#wsdl.porttype(loan2ServicePT)"/>
+             </sca:service>
+             <sca:reference name="risk2Assessor" >
+                 <sca:interface.wsdl interface="risk2AssessmentPT.wsdl#wsdl.porttype(risk2AssessmentPT)"/>
+             </sca:reference>
+         </sca:component>
+         
+         <sca:component name="risk2Assessor" >
+             <bpel:implementation.bpel process="ra:risk2AssessmentProcess" />
+             <sca:service name="risk2Assessor">
+                 <sca:interface.wsdl interface="risk2AssessmentPT.wsdl#wsdl.porttype(risk2AssessmentPT)"/>
+             </sca:service>
+         </sca:component>
+
+     </sca:composite>
+</switchyard>

--- a/bpel/src/test/resources/risk2AssessmentPT.wsdl
+++ b/bpel/src/test/resources/risk2AssessmentPT.wsdl
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?><wsdl:definitions
+targetNamespace="http://example.com/loan-approval/risk2Assessment/"
+xmlns:ens="http://example.com/loan-approval/xsd/error-messages/"
+xmlns:plnk="http://docs.oasis-open.org/wsbpel/2.0/plnktype"
+xmlns:tns="http://example.com/loan-approval/risk2Assessment/"
+xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+    <wsdl:types>
+		<xsd:schema targetNamespace="http://example.com/loan-approval/xsd/error-messages/">
+		  <xsd:element name="integer" type="xsd:integer" />
+		</xsd:schema>
+        <xsd:schema attributeFormDefault="unqualified" elementFormDefault="qualified" 
+                targetNamespace="http://example.com/loan-approval/risk2Assessment/" 
+                xmlns="http://www.w3.org/2001/XMLSchema">
+
+	        <element name="check">
+	            <complexType>
+	                <sequence>
+						<element name="firstName" type="xsd:string" />
+						<element name="name" type="xsd:string" />
+						<element name="amount" type="xsd:integer" />
+	                 </sequence>
+	            </complexType>
+	        </element>
+	         
+	        <element name="checkResponse">
+	            <complexType>
+	                <sequence>
+	                    <element name="level" type="string"/>
+	                 </sequence>
+	            </complexType>
+	        </element>
+         </xsd:schema>
+	</wsdl:types>
+	
+	<wsdl:message name="checkMessage">
+		<wsdl:part name="parameter" element="tns:check" />
+	</wsdl:message>
+
+	<wsdl:message name="checkResponseMessage">
+		<wsdl:part name="parameter" element="tns:checkResponse" />
+	</wsdl:message>
+
+	<wsdl:message name="errorMessage">
+		<wsdl:part name="errorCode" element="ens:integer" />
+	</wsdl:message>
+	
+	<wsdl:portType name="risk2AssessmentPT">
+		<wsdl:operation name="check">
+			<wsdl:input message="tns:checkMessage" />
+	<!--
+			<wsdl:output message="tns:checkResponseMessage" />
+	-->
+			<wsdl:fault name="loanProcessFault"
+					message="tns:errorMessage" />
+		</wsdl:operation>
+	</wsdl:portType>
+	
+	<plnk:partnerLinkType name="risk2AssessmentLT">
+		<plnk:role name="assessor" portType="tns:risk2AssessmentPT" />
+	</plnk:partnerLinkType>
+	
+    <wsdl:binding name="risk2Assessor_Binding" type="tns:risk2AssessmentPT">
+    	<soap:binding style="document"
+    		transport="http://schemas.xmlsoap.org/soap/http" />
+    	<wsdl:operation name="check">
+    		<soap:operation
+    			soapAction="http://example.com/loan-approval/wsdl/check" />
+    		<wsdl:input>
+    			<soap:body use="literal"
+    				namespace="http://example.com/loan-approval/wsdl/" />
+    		</wsdl:input>
+    		<wsdl:output>
+    			<soap:body use="literal"
+    				namespace="http://example.com/loan-approval/wsdl/" />
+    		</wsdl:output>
+    		<wsdl:fault name="loanProcessFault">
+    			<soap:fault use="literal" name="loanProcessFault" />
+    		</wsdl:fault>
+    	</wsdl:operation>
+    </wsdl:binding>
+    
+    <wsdl:service name="risk2Assessor">
+    	<wsdl:port name="risk2Assessor_Port" binding="tns:risk2Assessor_Binding">
+    		<soap:address location="http://127.0.0.1:8080/Quickstart_bpel_loan_approval/RiskAssessment" />
+    	</wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/bpel/src/test/resources/risk2_assessment.bpel
+++ b/bpel/src/test/resources/risk2_assessment.bpel
@@ -1,0 +1,85 @@
+<process name="risk2AssessmentProcess"
+   targetNamespace="http://example.com/loan-approval/risk2Assessment/"
+   xmlns="http://docs.oasis-open.org/wsbpel/2.0/process/executable"
+   xmlns:lns="http://example.com/loan-approval/risk2Assessment/"
+   suppressJoinFailure="yes">
+
+   <import importType="http://schemas.xmlsoap.org/wsdl/"
+      location="risk2AssessmentPT.wsdl"
+      namespace="http://example.com/loan-approval/risk2Assessment/" />
+
+   <partnerLinks>
+
+      <partnerLink name="assessor"
+         partnerLinkType="lns:risk2AssessmentLT"
+         myRole="assessor" />
+
+   </partnerLinks>
+
+   <variables>
+      <variable name="check" messageType="lns:checkMessage" />
+      <variable name="checkResponse" messageType="lns:checkResponseMessage" />
+      <variable name="faultResponse" messageType="lns:errorMessage" />
+   </variables>
+
+   <sequence>
+      <receive partnerLink="assessor" 
+         portType="lns:risk2AssessmentPT"
+         operation="check" 
+         variable="check"
+         createInstance="yes">
+      </receive>
+
+		<if>
+		<!-- $check.parameter/check/amount/text() >= 1000 
+		$check.parameter/lns:check/amount >= 1000
+		$check.parameter/check/firstName != 'Fred'
+		-->
+   			<condition>
+				<![CDATA[$check.parameter//amount >= 1000]]>
+			</condition>
+			<sequence>
+		        <assign validate="no" name="AssignFaultValue">
+		            <copy>
+		                <from><literal>
+		                	<integer xmlns="http://example.com/loan-approval/xsd/error-messages/">1</integer>
+						</literal></from>
+		                <to variable="faultResponse" part="errorCode"></to>
+		            </copy>
+		        </assign>
+				<!--throw faultName="lns:loanProcessFault" faultVariable="faultResponse" / -->
+	<!--
+			      <reply partnerLink="assessor" 
+			         portType="lns:risk2AssessmentPT"
+			         operation="check" 
+					 faultName="lns:loanProcessFault"
+			         variable="faultResponse">
+			
+			      </reply>
+	-->		
+			</sequence>
+			<else>
+				<sequence>
+				
+			        <assign validate="no" name="AssignName">
+			            <copy>
+			                <from><literal><tns:CheckResponse xmlns:tns="http://example.com/loan-approval/loanService/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+			  <tns:level>low</tns:level>
+			</tns:CheckResponse>
+			</literal></from>
+			                <to variable="checkResponse" part="parameter"></to>
+			            </copy>
+			        </assign>
+<!--			
+			      <reply partnerLink="assessor" 
+			         portType="lns:risk2AssessmentPT"
+			         operation="check" 
+			         variable="checkResponse">
+			      </reply>
+	-->
+				</sequence>
+			</else>
+		</if>
+   </sequence>
+
+</process>


### PR DESCRIPTION
Reorganize RiftsawServiceLocator$ServiceProxy.invoke so that both IN_OUT and IN_ONLY are both respected.   IN_ONLY can occur when the WSDL operation does not return output.
