### PR TITLE
SWITCHYARD-1970 Support custom quartz.properties

### DIFF
--- a/camel/camel-quartz/pom.xml
+++ b/camel/camel-quartz/pom.xml
@@ -35,6 +35,18 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard</groupId>
+            <artifactId>switchyard-common-camel</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-common-camel</artifactId>
         </dependency>

--- a/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/deploy/CamelQuartzActivator.java
+++ b/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/deploy/CamelQuartzActivator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.camel.quartz.deploy;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+
+import org.apache.camel.component.quartz.QuartzComponent;
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.common.type.Classes;
+import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
+import org.switchyard.config.model.composite.BindingModel;
+import org.switchyard.deploy.ServiceHandler;
+
+/**
+ * Camel quartz activator.
+ */
+public class CamelQuartzActivator extends BaseBindingActivator {
+
+    /**
+     * Creates new activator instance.
+     * 
+     * @param context Camel context.
+     * @param types Activation types.
+     */
+    public CamelQuartzActivator(SwitchYardCamelContext context, String[] types) {
+        super(context, types);
+    }
+
+    @Override
+    public ServiceHandler activateBinding(QName serviceName, BindingModel config) {
+        // SWITCHYARD-1970 - custom quartz.properties support
+        probeQuartzProperties();
+
+        return super.activateBinding(serviceName, config);
+    }
+
+    private void probeQuartzProperties() {
+        try {
+            URL props = Classes.getResource("org/quartz/quartz.properties");
+            if (props == null) {
+                return;
+            }
+        } catch (IOException e) {
+            return;
+        }
+
+        Set<QuartzComponent> components = getCamelContext().getRegistry().findByType(QuartzComponent.class);
+        if (components.isEmpty()) {
+            QuartzComponent quartz = getCamelContext().getInjector().newInstance(QuartzComponent.class);
+            getCamelContext().getWritebleRegistry().put("quartz", quartz);
+            components.add(quartz);
+        }
+        for (QuartzComponent quartz : components) {
+            if (quartz.getPropertiesFile() == null) {
+                quartz.setPropertiesFile("org/quartz/quartz.properties");
+            }
+        }
+    }
+
+}

--- a/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/deploy/CamelQuartzComponent.java
+++ b/camel/camel-quartz/src/main/java/org/switchyard/component/camel/quartz/deploy/CamelQuartzComponent.java
@@ -13,6 +13,8 @@
  */
 package org.switchyard.component.camel.quartz.deploy;
 
+import org.switchyard.common.camel.SwitchYardCamelContext;
+import org.switchyard.component.camel.common.deploy.BaseBindingActivator;
 import org.switchyard.component.camel.common.deploy.BaseBindingComponent;
 import org.switchyard.component.camel.quartz.model.v2.V2CamelQuartzBindingModel;
 
@@ -26,6 +28,11 @@ public class CamelQuartzComponent extends BaseBindingComponent {
      */
     public CamelQuartzComponent() {
         super("CamelQuartzComponent", V2CamelQuartzBindingModel.QUARTZ);
+    }
+
+    @Override
+    protected BaseBindingActivator createActivator(SwitchYardCamelContext context, String... types) {
+        return new CamelQuartzActivator(context, types);
     }
 
 }


### PR DESCRIPTION
Introduced `CamelQuartzActivator` in `camel-quartz` that searches `org/quartz/quartz.properties` in application's classpath and, if it exists, creates `QuartzComponent` and set its `PropertiesFile` property.
