### PR TITLE
SWITCHYARD-2393: BPM/Rules properties are not set in org.kie.api.runtime.Environment

### DIFF
--- a/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/exchange/KnowledgeExchangeHandler.java
+++ b/common/knowledge/src/main/java/org/switchyard/component/common/knowledge/exchange/KnowledgeExchangeHandler.java
@@ -35,6 +35,7 @@ import org.switchyard.component.common.knowledge.session.KnowledgeSession;
 import org.switchyard.component.common.knowledge.session.KnowledgeSessionFactory;
 import org.switchyard.component.common.knowledge.util.Environments;
 import org.switchyard.component.common.knowledge.util.Operations;
+import org.switchyard.component.common.knowledge.util.Propertys;
 import org.switchyard.component.common.knowledge.util.Resources;
 import org.switchyard.deploy.BaseServiceHandler;
 import org.switchyard.deploy.ServiceHandler;
@@ -50,6 +51,7 @@ import org.switchyard.metadata.ServiceOperation;
  */
 public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImplementationModel> extends BaseServiceHandler implements ServiceHandler {
 
+    private final Map<String, Object> _properties = new HashMap<String, Object>();
     private final String _deploymentId;
     private final M _model;
     private final ServiceDomain _serviceDomain;
@@ -67,6 +69,11 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      */
     public KnowledgeExchangeHandler(M model, ServiceDomain serviceDomain, QName serviceName) {
         super(serviceDomain);
+        // SWITCHYARD-2393: copy properties into environment (not just into session configuration)
+        Properties properties = Propertys.getProperties(model, null);
+        for (Map.Entry<Object, Object> property : properties.entrySet()) {
+            _properties.put((String)property.getKey(), property.getValue());
+        }
         // TODO: revisit how deploymentId is created and used
         _deploymentId = serviceName.toString();
         _model = model;
@@ -128,6 +135,8 @@ public abstract class KnowledgeExchangeHandler<M extends KnowledgeComponentImple
      */
     protected Map<String, Object> getEnvironmentOverrides() {
         Map<String, Object> env = new HashMap<String, Object>();
+        // SWITCHYARD-2393: copy properties into environment (not just into session configuration)
+        env.putAll(_properties);
         env.put(Environments.DEPLOYMENT_ID, getDeploymentId());
         return env;
     }


### PR DESCRIPTION
SWITCHYARD-2393: BPM/Rules properties are not set in org.kie.api.runtime.Environment
https://issues.jboss.org/browse/SWITCHYARD-2393

NOTE: This Pull Request will *only* work against SwitchYard 1.x. In SwitchYard 2.x, the common knowledge  code was greatly refactored. However, this bug was fixed already in that stream as part of SWITCHYARD-2397.