### PR TITLE
SWITCHYARD-2592 SCA cluster invocation doesn't work if both of consumer/...

### DIFF
--- a/sca/src/main/java/org/switchyard/component/sca/deploy/SCAComponent.java
+++ b/sca/src/main/java/org/switchyard/component/sca/deploy/SCAComponent.java
@@ -13,11 +13,24 @@
  */
 package org.switchyard.component.sca.deploy;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import javax.naming.InitialContext;
+
+import org.infinispan.Cache;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ParserRegistry;
+import org.infinispan.manager.DefaultCacheManager;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.logging.Logger;
 import org.switchyard.ServiceDomain;
 import org.switchyard.common.util.ProviderRegistry;
 import org.switchyard.component.sca.NOPEndpointPublisher;
 import org.switchyard.component.sca.RemoteEndpointPublisher;
 import org.switchyard.component.sca.SCALogger;
+import org.switchyard.config.Configuration;
 import org.switchyard.deploy.Activator;
 import org.switchyard.deploy.BaseComponent;
 
@@ -27,7 +40,16 @@ import org.switchyard.deploy.BaseComponent;
 public class SCAComponent extends BaseComponent {
     
     private static final String CONTEXT_PATH = "switchyard-remote";
+    private static final String CACHE_CONTAINER_ROOT = "java:jboss/infinispan/container/";
+    private static final String CACHE_NAME_PROPERTY = "cache-name";
+    private static final String CACHE_CONFIG_PROPERTY = "cache-config";
+    private static final String JGROUPS_CONFIG_PROPERTY = "jgroups-config";
+    private static final String DISABLE_REMOTE_TRANSACTION_PROPERTY = "disable-remote-transaction";
+
+    private Logger _log = Logger.getLogger(SCAComponent.class);
     private RemoteEndpointPublisher _endpointPublisher;
+    private Cache<String, String> _cache;
+    private boolean _disableRemoteTransaction = false;
 
     /**
      * Default constructor.
@@ -43,10 +65,42 @@ public class SCAComponent extends BaseComponent {
     }
     
     @Override
+    public void init(Configuration environment) {
+        super.init(environment);
+
+        // Determine the cache name
+        String cacheName = "cluster";
+        Configuration cacheNameConfig = environment.getFirstChild(CACHE_NAME_PROPERTY);
+        if (cacheNameConfig != null) {
+            cacheName = cacheNameConfig.getValue();
+        }
+        
+        // If a cache config is specified in the component configuration, then we 
+        // are managing the creation of the cache.  If not, then we look up a 
+        // cache manager and try to resolve the cache.
+        Configuration cacheFileConfig = environment.getFirstChild(CACHE_CONFIG_PROPERTY);
+        if (cacheFileConfig != null && cacheFileConfig.getValue() != null) {
+            Configuration jgroupsConfig = environment.getFirstChild(JGROUPS_CONFIG_PROPERTY);
+            createCache(cacheFileConfig.getValue(), cacheName, jgroupsConfig != null ? jgroupsConfig.getValue() : null);
+        } else {
+            lookupCache(cacheName);
+        }
+        if (_cache == null) {
+            SCALogger.ROOT_LOGGER.unableToResolveCacheContainer(cacheName);
+        }
+        
+        Configuration bridgeRemoteTxConfig = environment.getFirstChild(DISABLE_REMOTE_TRANSACTION_PROPERTY);
+        if (bridgeRemoteTxConfig != null) {
+            _disableRemoteTransaction = Boolean.parseBoolean(bridgeRemoteTxConfig.getValue());
+        }
+    }
+    
+    @Override
     public Activator createActivator(ServiceDomain domain) {
-        SCAActivator activator = new SCAActivator(getConfig());
+        SCAActivator activator = new SCAActivator(_cache);
         activator.setServiceDomain(domain);
         activator.setEndpointPublisher(_endpointPublisher);
+        activator.setDisableRemoteTransaction(_disableRemoteTransaction);
         return activator;
     }
 
@@ -67,5 +121,54 @@ public class SCAComponent extends BaseComponent {
             SCALogger.ROOT_LOGGER.noEndpointPublisherRegistered();
         }
         _endpointPublisher.init(CONTEXT_PATH);
+    }
+
+    private void createCache(String cacheConfig, String cacheName, String jgroupsConfig) {
+        ClassLoader origCl = Thread.currentThread().getContextClassLoader();
+        try {
+            InputStream configStream = null;
+            try {
+                File f = new File(cacheConfig);
+                if (f.exists() && f.isFile()) {
+                    configStream = new FileInputStream(f);
+                } else {
+                    configStream = SCAActivator.class.getClassLoader().getResourceAsStream(cacheConfig);
+                }
+
+                ClassLoader cacheClassLoader = DefaultCacheManager.class.getClassLoader();
+                Thread.currentThread().setContextClassLoader(cacheClassLoader);
+                ConfigurationBuilderHolder holder = new ParserRegistry(cacheClassLoader).parse(configStream);
+                if (jgroupsConfig != null) {
+                    holder.getGlobalConfigurationBuilder()
+                          .transport()
+                          .defaultTransport()
+                          .addProperty("configurationFile", jgroupsConfig);
+                }
+                _cache = new DefaultCacheManager(holder, true).getCache(cacheName);
+            } finally {
+                if (configStream != null) {
+                    try {
+                        configStream.close();
+                    } catch (Exception e) {
+                        e.fillInStackTrace();
+                    }
+                }
+           }
+        } catch (Exception ex) {
+            _log.debug("Failed to create cache for distributed registry", ex);
+        } finally {
+            Thread.currentThread().setContextClassLoader(origCl);
+        }
+    }
+    
+    private void lookupCache(String cacheName) {
+        // Attempt to resolve the cache container to use for the distributed registry through JNDI
+        try {
+            EmbeddedCacheManager cm = (EmbeddedCacheManager)
+                    new InitialContext().lookup(CACHE_CONTAINER_ROOT + cacheName);
+            _cache = cm.getCache();
+        } catch (Exception ex) {
+            _log.debug("Failed to lookup cache container for distributed registry", ex);
+        }
     }
 }

--- a/sca/src/test/java/org/switchyard/component/sca/deploy/SCAActivatorTest.java
+++ b/sca/src/test/java/org/switchyard/component/sca/deploy/SCAActivatorTest.java
@@ -2,31 +2,20 @@ package org.switchyard.component.sca.deploy;
 
 import javax.xml.namespace.QName;
 
-import junit.framework.Assert;
-
-import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.switchyard.component.sca.NOPEndpointPublisher;
-import org.switchyard.config.ConfigurationPuller;
 import org.switchyard.config.model.composite.SCABindingModel;
 import org.switchyard.config.model.composite.v1.V1SCABindingModel;
 import org.switchyard.config.model.switchyard.SwitchYardNamespace;
 
 public class SCAActivatorTest {
-    private static final String TEST_XML = "TestConfig.xml";
-    private ConfigurationPuller _cfg_puller;
     private SCAActivator activator;
     
     @Before
     public void setUp() throws Exception {
-        _cfg_puller = new ConfigurationPuller(); 
-        activator = new SCAActivator(_cfg_puller.pull(TEST_XML, getClass()));
-    }
-    
-    @After
-    public void after() {
-        _cfg_puller = null;
+        activator = new SCAActivator(null);
     }
     
     @Test


### PR DESCRIPTION
...producer are deployed onto same karaf node

Moved cache instance from activator to component so that all the SCA activator on a same runtime can share it