### PR TITLE
SWITCHYARD-2740 - SOAP response version mismatch at SOAP gateway binding

### DIFF
--- a/soap/src/main/java/org/switchyard/component/soap/util/SOAPUtil.java
+++ b/soap/src/main/java/org/switchyard/component/soap/util/SOAPUtil.java
@@ -360,10 +360,10 @@ public final class SOAPUtil {
      */
     public static SOAPFault addFault(SOAPMessage soapMessage) throws SOAPException {
         if (isSOAP12(soapMessage)) {
-            return soapMessage.getSOAPBody().addFault(SOAP12_FAULT_MESSAGE_TYPE, 
+            return soapMessage.getSOAPBody().addFault(SOAP12_RECEIVER_FAULT_TYPE,
                     SOAPMessages.MESSAGES.sendFailed());
         } else {
-            return soapMessage.getSOAPBody().addFault(SOAP11_FAULT_MESSAGE_TYPE, 
+            return soapMessage.getSOAPBody().addFault(SOAP11_SERVER_FAULT_TYPE,
                     SOAPMessages.MESSAGES.sendFailed());
         }
     }

--- a/soap/src/main/java/org/switchyard/component/soap/util/SOAPUtil.java
+++ b/soap/src/main/java/org/switchyard/component/soap/util/SOAPUtil.java
@@ -385,6 +385,23 @@ public final class SOAPUtil {
     }
 
     /**
+     * Generates a SOAP 1.1 or 1.2 Fault Message based on binding id, request SOAP message, and Exception passed.
+     *
+     * @param th The Exception
+     * @param bindingId SOAPBinding type
+     * @param request SOAPMessage to respond to
+     * @return The SOAP Message containing the Fault
+     * @throws SOAPException If the message could not be generated
+     */
+    public static SOAPMessage generateFault(final Throwable th, final String bindingId, final SOAPMessage request) throws SOAPException {
+        if (!isSOAP12(request)) {
+            return generateSOAP11Fault(th);
+        } else {
+            return generateFault(th, bindingId);
+        }
+    }
+
+    /**
      * Generates a SOAP 1.1 Fault Message based on the Exception passed.
      *
      * @param th The Exception.
@@ -593,13 +610,24 @@ public final class SOAPUtil {
      * @throws SOAPException If the message could not be generated.
      */
     public static SOAPMessage createMessage(String bindingId) throws SOAPException {
-        SOAPMessage message = null;
-        if (bindingId.equals(SOAPBinding.SOAP12HTTP_BINDING) || bindingId.equals(SOAPBinding.SOAP12HTTP_MTOM_BINDING)) {
-            message = SOAP12_MESSAGE_FACTORY.createMessage();
+        return getFactory(bindingId).createMessage();
+    }
+
+    /**
+     * Creates a SOAP Message of version 1.1 or 1.2 based on binding id and request SOAP message.
+     * The binding Id can be one of javax.xml.ws.soap.SOAPBinding ids.
+     * 
+     * @param bindingId SOAPBinding type
+     * @param request SOAPMessage to respond to
+     * @return javax.xml.soap.SOAPMessage
+     * @throws SOAPException If the message could not be generated.
+     */
+    public static SOAPMessage createMessage(String bindingId, SOAPMessage request) throws SOAPException {
+        if (!isSOAP12(request)) {
+            return SOAP11_MESSAGE_FACTORY.createMessage();
         } else {
-            message = SOAP11_MESSAGE_FACTORY.createMessage();
+            return createMessage(bindingId);
         }
-        return message;
     }
 
     /**

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPMessageTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPMessageTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.switchyard.component.soap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.test.MockHandler;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+/**
+ * Tests SOAP envelopes.
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(config = "soap-switchyard.xml", mixins = { HTTPMixIn.class })
+public class SOAPMessageTest {
+
+    private static final String SOAP11_ENDPOINT = "http://localhost:18001/soap11/HelloWebService";
+    private static final String SOAP12_ENDPOINT = "http://localhost:18001/soap12/HelloSOAP12Service";
+
+    //@formatter:off
+    private static final String RESPONSE =
+              "<test:sayHelloResponse xmlns:test=\"urn:switchyard-component-soap:test-ws:1.0\">"
+            + "   <return>Hello, SwitchYard!</return>"
+            + "</test:sayHelloResponse>";
+    private static final String FAULT = "<message>ERROR!</message>";
+    //@formatter:on
+
+    private SwitchYardTestKit _testKit;
+    private HTTPMixIn _httpMixIn;
+
+    private MockHandler _mock;
+
+    @Before
+    public void setUp() {
+        _mock = _testKit.registerInOutService("HelloSOAPService");
+    }
+
+    @Test
+    public void toSOAP11Endpoint_soap11() {
+        _mock.replyWithOut(RESPONSE);
+        _httpMixIn.postResourceAndTestXML(SOAP11_ENDPOINT, "soap11-request.xml", "soap11-response.xml");
+    }
+
+    @Test
+    public void toSOAP11Endpoint_soap11_fault() {
+        _mock.replyWithFault(FAULT);
+        _httpMixIn.postResourceAndTestXML(SOAP11_ENDPOINT, "soap11-request.xml", "soap11-fault.xml");
+    }
+
+    @Test
+    public void toSOAP11Endpoint_soap12() {
+        _mock.replyWithOut(RESPONSE);
+        _httpMixIn.postResourceAndTestXML(SOAP11_ENDPOINT, "soap12-request.xml", "soap11-fault-mismatch.xml");
+    }
+
+    @Test
+    public void toSOAP12Endpoint_soap11() {
+        _mock.replyWithOut(RESPONSE);
+        _httpMixIn.postResourceAndTestXML(SOAP12_ENDPOINT, "soap11-request.xml", "soap11-response.xml");
+    }
+
+    @Test
+    public void toSOAP12Endpoint_soap11_fault() {
+        _mock.replyWithFault(FAULT);
+        _httpMixIn.postResourceAndTestXML(SOAP12_ENDPOINT, "soap11-request.xml", "soap11-fault.xml");
+    }
+
+    @Test
+    public void toSOAP12Endpoint_soap12() {
+        _mock.replyWithOut(RESPONSE);
+        _httpMixIn.postResourceAndTestXML(SOAP12_ENDPOINT, "soap12-request.xml", "soap12-response.xml");
+    }
+
+    @Test
+    public void toSOAP12Endpoint_soap12_fault() {
+        _mock.replyWithFault(FAULT);
+        _httpMixIn.postResourceAndTestXML(SOAP12_ENDPOINT, "soap12-request.xml", "soap12-fault.xml");
+    }
+
+}

--- a/soap/src/test/java/org/switchyard/component/soap/SOAPUtilTest.java
+++ b/soap/src/test/java/org/switchyard/component/soap/SOAPUtilTest.java
@@ -40,8 +40,22 @@ public class SOAPUtilTest {
     @Test
     public void testSOAP12EmptyFaultString() throws Exception {
         final SOAPFault soapFault = SOAPUtil.createFault(new Throwable(""), SOAPBinding.SOAP12HTTP_BINDING, null);
-        
+
         final SOAPMessage message = SOAPUtil.generateSOAP12Fault(new SOAPFaultException(soapFault));
         Assert.assertNotNull("SOAPMessage should have been returned", message);
+    }
+
+    @Test
+    public void testAddFault_soap11() throws Exception {
+        final SOAPFault soapFault = SOAPUtil.addFault(SOAPUtil.createMessage(SOAPBinding.SOAP11HTTP_BINDING));
+        Assert.assertNotNull("SOAPFault should have been returned", soapFault);
+        Assert.assertEquals(SOAPUtil.SOAP11_FAULT_MESSAGE_TYPE, soapFault.getElementQName());
+    }
+
+    @Test
+    public void testAddFault_soap12() throws Exception {
+        final SOAPFault soapFault = SOAPUtil.addFault(SOAPUtil.createMessage(SOAPBinding.SOAP12HTTP_BINDING));
+        Assert.assertNotNull("SOAPFault should have been returned", soapFault);
+        Assert.assertEquals(SOAPUtil.SOAP12_FAULT_MESSAGE_TYPE, soapFault.getElementQName());
     }
 }

--- a/soap/src/test/resources/org/switchyard/component/soap/soap-switchyard.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap-switchyard.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" xmlns:soap="urn:switchyard-component-soap:config:1.0" name="SOAPMessageTest" targetNamespace="urn:test:SOAPMessageTest:1.0">
+  <sca:composite name="SOAPMessageTest" targetNamespace="urn:test:SOAPMessageTest:1.0">
+    <sca:service name="HelloSOAPService" promote="Dummy/HelloSOAPService">
+      <soap:binding.soap name="soap11">
+        <soap:wsdl>HelloWebService.wsdl</soap:wsdl>
+        <soap:socketAddr>:18001</soap:socketAddr>
+        <soap:contextPath>soap11</soap:contextPath>
+      </soap:binding.soap>
+      <soap:binding.soap name="soap12">
+        <soap:wsdl>HelloWebService1.2.wsdl</soap:wsdl>
+        <soap:socketAddr>:18001</soap:socketAddr>
+        <soap:contextPath>soap12</soap:contextPath>
+      </soap:binding.soap>
+    </sca:service>
+    <sca:component name="Dummy">
+      <sca:implementation.java class="org.switchyard.component.soap.DummyBean"/>
+      <sca:service name="HelloSOAPService">
+        <sca:interface.wsdl interface="HelloWebService.wsdl#wsdl.porttype(HelloWebService)"/>
+      </sca:service>
+    </sca:component>
+  </sca:composite>
+  <domain>
+    <properties>
+      <property name="org.switchyard.handlers.messageTrace.enabled" value="true"/>
+    </properties>
+  </domain>
+</switchyard>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap11-fault-mismatch.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap11-fault-mismatch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Body>
+        <soap:Fault>
+            <faultcode>soap:VersionMismatch</faultcode>
+            <faultstring>A SOAP 1.2 message is not valid when sent to a SOAP 1.1 only endpoint.</faultstring>
+        </soap:Fault>
+    </soap:Body>
+</soap:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap11-fault.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap11-fault.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header />
+    <SOAP-ENV:Body>
+        <SOAP-ENV:Fault>
+            <faultcode>SOAP-ENV:Server</faultcode>
+            <faultstring>SWITCHYARD035448: Send Failed</faultstring>
+            <detail>
+                <message>ERROR!</message>
+            </detail>
+        </SOAP-ENV:Fault>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap11-request.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap11-request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns2="urn:switchyard-component-soap:test-ws:1.0">
+    <SOAP-ENV:Header />
+    <SOAP-ENV:Body>
+        <ns2:sayHello>
+            <arg0>SwitchYard</arg0>
+        </ns2:sayHello>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap11-response.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap11-response.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Header />
+    <SOAP-ENV:Body>
+        <ns2:sayHelloResponse xmlns:ns2="urn:switchyard-component-soap:test-ws:1.0">
+            <return>Hello, SwitchYard!</return>
+        </ns2:sayHelloResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap12-fault.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap12-fault.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope">
+    <env:Header />
+    <env:Body>
+        <env:Fault>
+            <env:Code>
+                <env:Value>env:Receiver</env:Value>
+            </env:Code>
+            <env:Reason>
+                <env:Text xml:lang="en-US">SWITCHYARD035448: Send Failed</env:Text>
+            </env:Reason>
+            <env:Detail>
+                <message>ERROR!</message>
+            </env:Detail>
+        </env:Fault>
+    </env:Body>
+</env:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap12-request.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap12-request.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:ns2="urn:switchyard-component-soap:test-ws:1.0">
+    <SOAP-ENV:Header />
+    <SOAP-ENV:Body>
+        <ns2:sayHello>
+            <arg0>SwitchYard</arg0>
+        </ns2:sayHello>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/soap/src/test/resources/org/switchyard/component/soap/soap12-response.xml
+++ b/soap/src/test/resources/org/switchyard/component/soap/soap12-response.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope">
+    <SOAP-ENV:Header />
+    <SOAP-ENV:Body>
+        <ns2:sayHelloResponse xmlns:ns2="urn:switchyard-component-soap:test-ws:1.0">
+            <return>Hello, SwitchYard!</return>
+        </ns2:sayHelloResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
Fix for: https://issues.jboss.org/browse/SWITCHYARD-2740

Changed `InboundHandler` to adhere to the SOAP version of request when creating a SOAP response. Unit tests also developed.
